### PR TITLE
feat: Multi-Material Slot Detection, Assignment & Routing (v1.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [1.3.0] - 2026-07-27
+
+### Added
+- **Multi-Material Slot Detection & Regex:** Regex engine detects per-slot material tags (`(?P<material>...)`) for assets with multiple material slots (e.g. `T_Chair_Metal_D`, `T_Chair_Wood_D`).
+- **Automated Subfolder Routing:** Multi-material assets automatically place Material Instances in `/Materials/` and textures in `/Textures/` subfolders, while single-material assets remain flat under `/Game/{category}/{base_name}/`.
+- **Per-Slot Material Instance Generation:** Generates slot-specific Material Instances (`MI_<MeshName>_<SlotName>`) and links them directly to matching static mesh material slot indices in Unreal Engine.
+- **Multi-Slot Transparency Popup Integration:** Transparency scanning (`scan_for_transparency`) inspects each material slot independently, allowing artists to select blend modes per slot.
+
+### Fixed
+- **OBJ Importer Safety:** Removed unsupported `.obj` file extension check to prevent `FbxImportUI` runtime exceptions during batch processing.
+
 ## [1.2.0] - 2026-07-21
 
 ### Added

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -2,10 +2,17 @@
 
 AssetPort parses filenames using a regex-based parser. To ensure that your meshes and textures are imported, categorized, and connected correctly, name your files using the following convention structure:
 
+### Single-Material Assets:
 ```text
 [Prefix]_[Category]_[BaseName]_[Suffix].[extension]
 ```
 *Example:* `SM_env_WallStone.fbx` or `T_env_WallStone_N.png`
+
+### Multi-Material Assets:
+```text
+[Prefix]_[Category]_[BaseName]_[MaterialSlotName]_[Suffix].[extension]
+```
+*Example:* `T_env_Chair_Metal_D.png` or `T_env_Chair_Wood_N.png`
 
 ---
 
@@ -61,7 +68,18 @@ Suffixes determine how textures are mapped inside the created **Material Instanc
 
 ---
 
-## 4. Custom Master Material Setup Guide
+## 4. Multi-Material Asset Behavior
+
+When `AssetPort` detects a `[MaterialSlotName]` tag in texture filenames (e.g. `Metal` or `Wood` in `T_Chair_Metal_D`):
+
+1. **Per-Slot Material Instances**: Generates individual Material Instances for each slot (`MI_Chair_Metal`, `MI_Chair_Wood`).
+2. **Mesh Slot Linkage**: Automatically assigns each Material Instance to the matching material slot name on the `StaticMesh`.
+3. **Automated Subfolder Routing**:
+   * **Single-Material Assets**: Placed 100% flat inside `/Game/[Category]/[BaseName]/`.
+   * **Multi-Material Assets**: Material Instances are routed to `/Game/[Category]/[BaseName]/Materials/` and textures to `/Game/[Category]/[BaseName]/Textures/`.
+   
+
+## 5. Custom Master Material Setup Guide
 
 If you configure a custom Master Material in `importer_config.json` via the `"parent_material"` property, your master material must use specific parameter names for AssetPort to correctly bind the scanned textures.
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ An automated, pipeline-friendly batch importer and organizer for **Unreal Engine
 * **⚡ Responsive Progress Dialog**: Displays a cancellable progress bar via `unreal.ScopedSlowTask` during saves and material compilation, preventing editor hangs on large batches.
 * **👁️ Interactive Preview Mode (Dry Run)**: Run a simulation scan to view the proposed folder routing and clean asset tree in a dedicated EUW window (`EUW_AssetPort_Preview`) before performing an actual import.
 * **💎 Automated Transparency & Blend Mode Management**: Auto-detects alpha channels in Base Colour textures (PNG, TGA, EXR) and launches an interactive EUW popup (`EUW_TransparencySetup`) for artists to select Blend Modes (`Masked` vs `Translucent`). Automatically assigns `M_Master_Masked` or `M_Master_Translucent` and configures `UseBaseColourAlpha` switches.
+* **🎭 Multi-Material Slot Detection & Subfolder Routing**: Automatically detects assets with multiple material slots (e.g., `T_Chair_Metal_D`, `T_Chair_Wood_D`). Generates per-slot Material Instances (`MI_Chair_Metal`, `MI_Chair_Wood`), links each to its corresponding static mesh slot, and routes assets into `/Materials/` and `/Textures/` subfolders. Single-material assets remain 100% flat!
 
 ---
 

--- a/asset_port/Validator.py
+++ b/asset_port/Validator.py
@@ -20,7 +20,7 @@ def asset_validator(asset : DetectedAsset ):
     if file_size > 100*1024*1024 and asset.asset_type == AssetType.TEXTURE:
         warnings.append("Texture Size is bigger than 100 MB")
         
-    extensions = [".obj",".fbx",".png",".tga", ".jpg", ".exr"]
+    extensions = [".fbx",".png",".tga", ".jpg", ".exr"]
     extension = asset.extension
     lower_extension = extension.lower()
     

--- a/asset_port/detector.py
+++ b/asset_port/detector.py
@@ -70,6 +70,7 @@ class AssetDetector:
             rf"^(?:(?P<prefix>{prefix_pattern})_)?"
             rf"(?:(?P<category>{category_pattern})_)?"
             rf"(?P<base>.*?)"
+            rf"(?:_(?p<material>[A-Za-z0-9]+))?"
             rf"(?:_(?P<suffix>{suffix_pattern}))?$"
                    
         )
@@ -94,7 +95,8 @@ class AssetDetector:
                 asset_type=AssetType.UNKNOWN,
                 texture_slot=None,
                 extension=path_obj.suffix,
-                category=None
+                category=None,
+                material_slot_name=None
             )
         
         group = match.groupdict()
@@ -106,6 +108,9 @@ class AssetDetector:
         category_str = category_raw.lower() if category_raw else ""
         
         base_name = group.get("base")
+        
+        material_raw = group.get("material")
+        material_slot_name = material_raw if material_raw else None
         
         suffix_raw = group.get("suffix")
         suffix = suffix_raw if suffix_raw else ""
@@ -130,6 +135,7 @@ class AssetDetector:
             texture_slot= texture_slot,
             extension= path_obj.suffix,
             category=category,
+            material_slot_name=material_slot_name
         )
         
         return detected_asset
@@ -148,6 +154,10 @@ class AssetDetector:
             group = groups[asset.base_name]
             if asset.asset_type == AssetType.TEXTURE:
                 group.texture_list.append(asset)
+                
+                if asset.material_slot_name not in group.material_slots:
+                    group.material_slots[asset.material_slot_name] = []
+                group.material_slots[asset.material_slot_name].appem(asset)
                 
             elif asset.asset_type in (AssetType.SKELETAL_MESH, AssetType.STATIC_MESH):
                 group.mesh = asset

--- a/asset_port/detector.py
+++ b/asset_port/detector.py
@@ -70,7 +70,7 @@ class AssetDetector:
             rf"^(?:(?P<prefix>{prefix_pattern})_)?"
             rf"(?:(?P<category>{category_pattern})_)?"
             rf"(?P<base>.*?)"
-            rf"(?:_(?p<material>[A-Za-z0-9]+))?"
+            rf"(?:_(?P<material>[A-Za-z0-9]+))?"
             rf"(?:_(?P<suffix>{suffix_pattern}))?$"
                    
         )
@@ -155,9 +155,10 @@ class AssetDetector:
             if asset.asset_type == AssetType.TEXTURE:
                 group.texture_list.append(asset)
                 
-                if asset.material_slot_name not in group.material_slots:
-                    group.material_slots[asset.material_slot_name] = []
-                group.material_slots[asset.material_slot_name].appem(asset)
+                if asset.material_slot_name:
+                    if asset.material_slot_name not in group.material_slots:
+                        group.material_slots[asset.material_slot_name] = []
+                    group.material_slots[asset.material_slot_name].append(asset)
                 
             elif asset.asset_type in (AssetType.SKELETAL_MESH, AssetType.STATIC_MESH):
                 group.mesh = asset

--- a/asset_port/detector.py
+++ b/asset_port/detector.py
@@ -108,13 +108,17 @@ class AssetDetector:
         category_str = category_raw.lower() if category_raw else ""
         
         base_name = group.get("base")
-        
         material_raw = group.get("material")
-        material_slot_name = material_raw if material_raw else None
-        
         suffix_raw = group.get("suffix")
-        suffix = suffix_raw if suffix_raw else ""
         
+        if material_raw and not suffix_raw:
+            if material_raw.lower() in SUFFIX_MAP:
+                suffix_raw = material_raw
+                material_raw = None
+                
+        material_slot_name = material_raw if material_raw else None
+        suffix = suffix_raw if suffix_raw else ""
+            
         
         asset_type = PREFIX_MAP.get(prefix, AssetType.UNKNOWN)
         

--- a/asset_port/gui_helper.py
+++ b/asset_port/gui_helper.py
@@ -19,19 +19,26 @@ TRANSPARENCY_ID = unreal.Name("/Game/Python/Widgets/EUW_TransparencySetup.EUW_Tr
 def scan_for_transparency(groups):
     items = []
     for group in groups:
-        has_mask = any(t.texture_slot == TextureSlot.OPACITY_MASK for t in group.texture_list)
+        if group.is_multi_material:
+            slot_to_scan = {f"MI_{group.base_name}_{slot}": texs for slot, texs in group.material_slots.items()}
+        else:
+            slot_to_scan = {f"MI_{group.base_name}": group.texture_list}
+            
+        for mi_name, textures in slot_to_scan.items():
+            
+            has_mask = any(t.texture_slot == TextureSlot.OPACITY_MASK for t in textures)
         
-        has_opacity = any(t.texture_slot == TextureSlot.OPACITY for t in group.texture_list)
+            has_opacity = any(t.texture_slot == TextureSlot.OPACITY for t in textures)
         
-        base_colour = next((t for t in group.texture_list if t.texture_slot == TextureSlot.BASE_COLOUR), None)
-        has_alpha = base_colour.has_alpha if base_colour else False
+            base_colour = next((t for t in textures if t.texture_slot == TextureSlot.BASE_COLOUR), None)
+            has_alpha = base_colour.has_alpha if base_colour else False
         
-        if has_mask:
-            items.append((group, "Masked"))
-        elif has_opacity:
-            items.append((group, "Translucent"))
-        elif has_alpha:
-            items.append((group,"Masked"))
+            if has_mask:
+                items.append((mi_name, "Masked"))
+            elif has_opacity:
+                items.append((mi_name, "Translucent"))
+            elif has_alpha:
+                items.append((mi_name,"Masked"))
             
     return items
     
@@ -47,7 +54,7 @@ def show_transparency_popup(items, on_confirm_callback):
     
     transparency_widget = subsystem.spawn_and_register_tab(widget_asset)
     if transparency_widget:
-        name = [f"MI_{item[0].base_name}" for item in items]
+        name = [item[0] for item in items]
         default = [item[1] for item in items]
         
         transparency_widget.set_editor_property("MaterialNames", name)
@@ -74,19 +81,19 @@ def on_popup_confirm(items, on_confirm_callback):
             count = scroll_box.get_children_count()
             rows = [scroll_box.get_child_at(i) for i in range(count)]
             
-            for (group,_), row in zip(items, rows):
+            for (mi_name,_), row in zip(items, rows):
                 
                 try:
                     combo = row.get_editor_property("ComboBox_BlendMode")
                     if combo:
                         selected_mode = combo.get_selected_option()
-                        decisions[group.base_name] =  selected_mode
-                        unreal.log(f"AssetPort: Set {group.base_name} blend mode -> {selected_mode}")
+                        decisions[mi_name] =  selected_mode
+                        unreal.log(f"AssetPort: Set {mi_name} blend mode -> {selected_mode}")
                     else:
-                        unreal.log_warning(f"AssetPort: Could not find ComboBox on row for {group.base_name}")
+                        unreal.log_warning(f"AssetPort: Could not find ComboBox on row for {mi_name}")
                         
                 except Exception as err_row:
-                    unreal.log_error(f"AssetPort: Error reading row for {group.base_name}: {err_row}")
+                    unreal.log_error(f"AssetPort: Error reading row for {mi_name}: {err_row}")
                 
                    
     except Exception as err_main:
@@ -106,8 +113,7 @@ def on_popup_cancel(on_confirm_callback):
     transparency_widget = None
     on_confirm_callback({})
             
-        
-        
+              
 def execute_import_pipeline(folder_path, category):
     importer = AssetImporter()
     
@@ -228,10 +234,17 @@ def on_preview_clicked():
                 import_asset_name.append(f"{display_folder}|{mesh_name}")
             for texture in group.texture_list:
                 texture_name = texture.ue_path.split("/")[-1]
-                import_asset_name.append(f"{display_folder}|{texture_name}")
+                if group.is_multi_material:
+                    import_asset_name.append(f"{display_folder}/Textures|{texture_name}")
+                else:
+                    import_asset_name.append(f"{display_folder}|{texture_name}")
         
             if config.auto_create_mi:
-                import_asset_name.append(f"{display_folder}|MI_{group.base_name}")   
+                if group.is_multi_material:
+                    for slot_name in group.material_slots.keys():
+                        import_asset_name.append(f"{display_folder}/Materials|MI_{group.base_name}_{slot_name}")
+                else:
+                    import_asset_name.append(f"{display_folder}|MI_{group.base_name}")   
                 
         for warning in report.warnings:
             failed_asset_name.append(warning)

--- a/asset_port/gui_helper.py
+++ b/asset_port/gui_helper.py
@@ -235,14 +235,14 @@ def on_preview_clicked():
             for texture in group.texture_list:
                 texture_name = texture.ue_path.split("/")[-1]
                 if group.is_multi_material:
-                    import_asset_name.append(f"{display_folder}/Textures|{texture_name}")
+                    import_asset_name.append(f"{display_folder}|Textures/{texture_name}")
                 else:
                     import_asset_name.append(f"{display_folder}|{texture_name}")
         
             if config.auto_create_mi:
                 if group.is_multi_material:
                     for slot_name in group.material_slots.keys():
-                        import_asset_name.append(f"{display_folder}/Materials|MI_{group.base_name}_{slot_name}")
+                        import_asset_name.append(f"{display_folder}|Materials/MI_{group.base_name}_{slot_name}")
                 else:
                     import_asset_name.append(f"{display_folder}|MI_{group.base_name}")   
                 

--- a/asset_port/importer.py
+++ b/asset_port/importer.py
@@ -70,8 +70,7 @@ class AssetImporter():
         
     def build_materials(self, group_asset, decisions=None, report= None):
         for group in group_asset:
-            mode = decisions.get(group.base_name, "Opaque") if decisions else "Opaque"
-            mi_report = create_material_instance(group, self.config, mode)
+            mi_report = create_material_instance(group, self.config, decisions)
             if report and mi_report.success:
                 report.mis_created += 1
                 if mi_report.mesh_linked:

--- a/asset_port/importer.py
+++ b/asset_port/importer.py
@@ -119,7 +119,7 @@ class AssetImporter():
                 task.automated = True
                 task.save = True
             
-                if detected_asset.extension.lower() in (".fbx", ".obj") or detected_asset.asset_type in (AssetType.STATIC_MESH, AssetType.SKELETAL_MESH):
+                if detected_asset.extension.lower() == ".fbx" or detected_asset.asset_type in (AssetType.STATIC_MESH, AssetType.SKELETAL_MESH):
                     task.options = get_mesh_setting(detected_asset)
             
                 tasks.append(task) 

--- a/asset_port/importer.py
+++ b/asset_port/importer.py
@@ -140,7 +140,10 @@ class AssetImporter():
         for group in group_asset:
             ref_asset = group.mesh or (group.texture_list[0] if group.texture_list else None)
             if ref_asset and ref_asset.ue_path:
-                group.folder_path = "/".join(ref_asset.ue_path.split("/")[:-1])   
+                folder_parts = ref_asset.ue_path.split("/")[:-1]
+                if folder_parts and folder_parts[-1] == "Textures":
+                    folder_parts = folder_parts[:-1]
+                group.folder_path = "/".join(folder_parts)   
                 
                 group_warnings = group_validator(group)
                 if group_warnings:

--- a/asset_port/materials.py
+++ b/asset_port/materials.py
@@ -2,94 +2,110 @@ import unreal
 from asset_port.models import AssetGroup , MaterialBuildResult, TextureSlot
 from asset_port.config import ImporterSettings
 
-def create_material_instance(group : AssetGroup, config: ImporterSettings, blend_mode: str ="Opaque"):
+def create_material_instance(group : AssetGroup, config: ImporterSettings, decisions: dict = None):
 
     folder_path = group.folder_path
-    
-    if blend_mode == "Masked":
-        m_master = config.parent_material_masked
-    elif blend_mode == "Translucent":
-        m_master = config.parent_material_translucent
-    else:
-        m_master = config.parent_material_opaque
-    
-    unreal.log(f"AssetPort DEBUG: Building {group.base_name} with blend_mode='{blend_mode}', master_path='{m_master}'")
-    parent_material = unreal.EditorAssetLibrary.load_asset(m_master)
-    unreal.log(f"AssetPort DEBUG: Loaded parent_material='{parent_material}'")
-    
-        
-    mi_path = f"{folder_path}/MI_{group.base_name}"
-    mi = None
-    mesh = group.mesh
+   
     material_report = MaterialBuildResult(base_name=group.base_name)
+    mesh_object = unreal.EditorAssetLibrary.load_asset(group.mesh.ue_path) if group.mesh else None
     
-    if unreal.EditorAssetLibrary.does_asset_exist(mi_path):
-        if not config.replace_existing:
-            mi = unreal.EditorAssetLibrary.load_asset(mi_path)
-            
+    if group.is_multi_material:
+       slot_to_process = group.material_slots
+    else:    
+       slot_to_process = {"": group.texture_list}
+    
+    for slot_name, textures in slot_to_process.items():
+        if group.is_multi_material:
+            mi_name = f"MI_{group.base_name}_{slot_name}"
+            mi_package = f"{folder_path}/Materials"
         else:
-            unreal.EditorAssetLibrary.delete_asset(mi_path)
-            
-    mi_name = f"MI_{group.base_name}"      
-      
-    if mi is None:
-        factory =unreal.MaterialInstanceConstantFactoryNew()
+            mi_name = f"MI_{group.base_name}"
+            mi_package = folder_path
         
-        mi = unreal.AssetToolsHelpers.get_asset_tools().create_asset(
-            asset_name=mi_name,
-            package_path= group.folder_path,
-            asset_class= unreal.MaterialInstanceConstant,
-            factory=factory
-            
+        mi_path =f"{mi_package}/{mi_name}"
+        
+        blend_mode = decisions.get(mi_name, "Opaque") if decisions else "Opaque"
+        
+        if blend_mode =="Masked":
+            m_master = config.parent_material_masked
+        elif blend_mode == "Translucent":
+            m_master = config.parent_material_translucent
+        else:
+            m_master = config.parent_material_opaque
+        
+        parent_material = unreal.EditorAssetLibrary.load_asset(m_master)
+        
+        mi = None
+        if unreal.EditorAssetLibrary.does_asset_exist(mi_path):
+            if not config.replace_existing:
+                mi = unreal.EditorAssetLibrary.load_asset(mi_path)
+            else:
+                unreal.EditorAssetLibrary.delete_asset(mi_path)
+                
+        if mi is None:
+            factory = unreal.MaterialInstanceConstantFactoryNew()
+            mi = unreal.AssetToolsHelpers.get_asset_tools().create_asset(
+                asset_name=mi_name,
+                package_path=mi_package,
+                asset_class=unreal.MaterialInstanceConstant,
+                factory=factory
             )
-             
-    parent_material = unreal.EditorAssetLibrary.load_asset(m_master)
-    mi.set_editor_property("parent", parent_material)
-    
-    if blend_mode in ("Masked","Translucent"):
-        base_color_tex = next((t for t in group.texture_list if t.texture_slot == TextureSlot.BASE_COLOUR), None)
-        use_alpha = base_color_tex.has_alpha if base_color_tex else False
-        
-        unreal.MaterialEditingLibrary.set_material_instance_static_switch_parameter_value(
-            mi,
-            "UseBaseColourAlpha",
-            value=use_alpha
-        )  
-    
-    for texture in group.texture_list:
-        texture_path = texture.ue_path
-        texture_object = unreal.EditorAssetLibrary.load_asset(texture_path)
-        
-        param_name = texture.texture_slot.value
-        if texture.texture_slot == TextureSlot.OPACITY_MASK:
-            param_name = "OpacityMask"
-        elif texture.texture_slot == TextureSlot.OPACITY:
-            param_name = "Opacity"
             
-        unreal.MaterialEditingLibrary.set_material_instance_texture_parameter_value(
-            mi,
-            param_name,
-            texture_object
-            )
-        material_report.texture_assigned[param_name] = texture.ue_path
-        if texture.texture_slot == TextureSlot.ORM:
+        mi.set_editor_property("parent", parent_material)
+        
+        if blend_mode in ("Masked", "Translucent"):
+            base_color_tex = next((t for t in textures if t.texture_slot == TextureSlot.BASE_COLOUR),None)
+            use_alpha = base_color_tex.has_alpha if base_color_tex else False
+            
             unreal.MaterialEditingLibrary.set_material_instance_static_switch_parameter_value(
                 mi,
-                "UseORM",
-                value= True
+                "UseBaseColourAlpha",
+                value=use_alpha
             )
-    
-    if mesh is not None:
+            
+            
+        for texture in textures:
+            texture_object = unreal.EditorAssetLibrary.load_asset(texture.ue_path)
+            param_name = texture.texture_slot.value
+            if texture.texture_slot == TextureSlot.OPACITY_MASK:
+                param_name = "OpacityMask"
+            elif texture.texture_slot == TextureSlot.OPACITY:
+                param_name = "Opacity"
+                
+                
+            unreal.MaterialEditingLibrary.set_material_instance_texture_parameter_value(
+                mi,
+                param_name,
+                texture_object
+            )
+            material_report.texture_assigned[param_name] = texture.ue_path
+            if texture.texture_slot == TextureSlot.ORM:
+                unreal.MaterialEditingLibrary.set_material_instance_static_switch_parameter_value(
+                    mi,
+                    "UseORM",
+                    value=True
+                )
+                
+        unreal.EditorAssetLibrary.save_loaded_asset(mi)
         
-        mesh_object = unreal.EditorAssetLibrary.load_asset(mesh.ue_path)
-        mesh_object.set_material(0,mi)
-        unreal.EditorAssetLibrary.save_loaded_asset(mesh_object)
-        material_report.mesh_linked = mesh.base_name
-        
-    unreal.EditorAssetLibrary.save_loaded_asset(mi)
-           
-    material_report.base_name = mi_name
-    material_report.mi_path = mi_path
+        if mesh_object:
+            if group.is_multi_material:
+                static_mats = mesh_object.get_editor_property("static_materials")
+                for idx ,mat_slot in enumerate(static_mats):
+                    slot_str = str(mat_slot.get_editor_property("material_slot_name"))
+                    
+                    if slot_name.lower() in slot_str.lower() or slot_str.lower() in slot_name.lower():
+                        mesh_object.set_material(idx, mi)
+                        unreal.log(f"AssetPort: Assigned {mi_name} to slot [{idx}]'{slot_name}'")
+                        break
+                    
+            else:
+                mesh_object.set_material(0,mi)
+                
+            unreal.EditorAssetLibrary.save_loaded_asset(mesh_object)
+            material_report.mesh_linked = group.mesh.base_name
+            
+    material_report.base_name = group.base_name
     material_report.success = True
-        
     return material_report
+    

--- a/asset_port/models.py
+++ b/asset_port/models.py
@@ -37,6 +37,7 @@ class DetectedAsset:
     category : Optional[str] = None
     ue_path : Optional[str]= None
     has_alpha : bool = False
+    material_slot_name : Optional[str] = None
     
 @dataclass
 class AssetGroup:

--- a/asset_port/models.py
+++ b/asset_port/models.py
@@ -43,8 +43,15 @@ class AssetGroup:
     base_name : str
     mesh : Optional[DetectedAsset] = None
     texture_list : list[DetectedAsset] = field(default_factory=list)
+    material_slots : dict[str, list[DetectedAsset]] = field(default_factory=dict)
     category : Optional[str] = None
     folder_path : Optional[str] = None
+    @property
+    def is_multi_material(self) -> bool:
+        return len(self.material_slots) > 1
+    
+    
+    
     
 @dataclass
 class ImportResult:

--- a/asset_port/router.py
+++ b/asset_port/router.py
@@ -1,6 +1,6 @@
 from pathlib import Path
-from asset_port.detector import AssetDetector
-from asset_port.models import DetectedAsset
+from asset_port.detector import AssetDetector 
+from asset_port.models import DetectedAsset, AssetType
 from typing import Optional
 class AssetRouter():
     
@@ -43,11 +43,16 @@ class AssetRouter():
             suffix = asset.suffix
             
         else:
-            suffix =f"_{asset.suffix}"           
+            suffix =f"_{asset.suffix}"      
             
-        folder_path = f"/Game/{category}/{asset.base_name}"
-        
-        asset_path = f"/Game/{category}/{asset.base_name}/{prefix}{asset.base_name}{suffix}"        
+        if asset.asset_type == AssetType.TEXTURE and asset.material_slot_name:
+            folder_path = f"/Game/{category}/{asset.base_name}/Textures"
+            asset_name = f"{prefix}{asset.base_name}_{asset.material_slot_name}{suffix}"
+        else:    
+            folder_path = f"/Game/{category}/{asset.base_name}"
+            asset_name = f"{prefix}{asset.base_name}{suffix}"
+            
+        asset_path = f"{folder_path}/{asset_name}"        
             
         return folder_path, asset_path
         


### PR DESCRIPTION
added multi-material asset support and subfolder routing:

- auto detect material slots in texture names (like T_Chair_Metal_D)
- create per-slot MIs and link them to matching mesh slots
- route multi-material assets to /Materials and /Textures subfolders (single-material assets stay flat)
- updated transparency popup and preview UI for multi-material slots
- removed obj check to fix fbx importer crash
- updated readme, changelog, and conventions for v1.3.0