### PR TITLE
feat: add atlas & modular kit detection and import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [1.5.0] - 2026-08-22
+### Added
+- **Atlas & Modular Kit Grouping**: Hyphen-delimited kit mesh detection (`SM_Mesh-KitName`) linking multiple static meshes to a single shared PBR texture set.
+- **Dedicated Kit Folder Router**: Flat routing for all kit assets into `/Game/{Category}/{KitName}/`.
+- **Automated Kit Mesh Renaming**: Automatically strips kit suffixes during Unreal asset creation (e.g., `SM_Rock01-RockKit.fbx` $\rightarrow$ `SM_Rock01`).
+- **Shared Atlas Material Instance Generation**: `create_atlas_material_instance` builds and assigns a single shared MI (`MI_{KitName}`) to Slot 0 across all kit static meshes.
+- **Atlas Group Validation**: `atlas_group_validator` checks for orphaned kit meshes, missing PBR maps, and single-mesh kits.
+- **Preview UI Kit Badges**: Dry Run preview tree displays kit folders with `[Atlas: X Meshes]` badges.
+- **Pipeline Statistics Logging**: Tracks `Atlas Groups` found and `Atlas Meshes Imported` in console and summary reports.
+### Refactored & Fixed
+- **Decoupled 3-Phase Import Architecture**: Separated filesystem discovery, domain grouping, and task generation into clean, independent pipeline phases.
+- **Task-Asset Tuple Pairing**: Replaced uncoordinated list indices with direct `(asset, task)` tuple pairing, permanently resolving UDIM and batch import desynchronization.
+
+
 ## [1.4.0] - 2026-07-31
 ### Added
 - **UDIM Streaming Virtual Texture Support**: Automatically detects UDIM tile sequences (`_1001` through `_1999`) and imports them as single Streaming Virtual Textures. Secondary tile tasks are filtered to prevent import collisions.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -19,7 +19,15 @@ AssetPort parses filenames using a regex-based parser. To ensure that your meshe
 [Prefix]_[Category]_[BaseName]_[Suffix]_[TileID].[extension]
 ```
 *Example*: `T_env_Door_N_1001.png`, `T_env_Door_N_1002.png`
+
+### Atlas / Modular Kit Assets:
+```text
+Mesh:    [Prefix]_[Category]_[IndividualName]-[KitName].[extension]
+Texture: [Prefix]_[Category]_[KitName]_[Suffix].[extension]
+```
+*Example*: `SM_env_Rock01-RockKit.fbx`, `SM_env_Rock02-RockKit.fbx`, `T_env_RockKit_D.png`, `T_env_RockKit_ORM.png`
 ---
+
 
 ## 1. Prefixes (Asset Type)
 
@@ -82,7 +90,6 @@ When `AssetPort` detects a `[MaterialSlotName]` tag in texture filenames (e.g. `
 3. **Automated Subfolder Routing**:
    * **Single-Material Assets**: Placed 100% flat inside `/Game/[Category]/[BaseName]/`.
    * **Multi-Material Assets**: Material Instances are routed to `/Game/[Category]/[BaseName]/Materials/` and textures to `/Game/[Category]/[BaseName]/Textures/`.
-   
 
 ## 5. Custom Master Material Setup Guide
 
@@ -115,3 +122,12 @@ Ensure your Master Material defines texture parameters matching these exact name
 If a texture's suffix doesn't match any known slots, or if a slot is not found on your custom Master Material:
 * **Safe Fallback:** The assignment will be silently ignored.
 * **Pipeline Continues:** It will not raise an error or crash the import process. The mesh will still be imported, the material instance will be created, other matching parameters will be connected, and the material will be assigned to the mesh successfully.
+
+## 6. Atlas & Modular Kit Behavior
+AssetPort supports texture atlas workflows where multiple static meshes share a single texture set and Material Instance:
+1. **Hyphen Delimiter (`-`)**: The hyphen is **reserved exclusively** for Atlas / Kit meshes to separate the individual mesh name from its shared kit name (`SM_PropName-KitName.fbx`).
+2. **Automated Clean Naming**: When imported into Unreal Engine, kit meshes are automatically cleaned and renamed without the kit suffix (e.g. `SM_Rock01-RockKit.fbx` $\rightarrow$ `SM_Rock01`).
+3. **Shared Material Instance**: A single Material Instance (`MI_[KitName]`) is generated and linked to Slot 0 across all meshes in the kit.
+4. **Flat Folder Routing**: All kit meshes, textures, and the shared Material Instance are placed flat inside `/Game/[Category]/[KitName]/`.
+> [!IMPORTANT]
+> **Hyphen Constraint:** Do not use hyphens (`-`) in standard non-kit asset filenames, as AssetPort treats hyphens as the kit separator.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ An automated, pipeline-friendly batch importer and organizer for **Unreal Engine
 
 * **🧩 UDIM & Virtual Texture Support**: Automatically detects UDIM tile sequences (`_1001` to `_1999`) and 4K Auto-VTs, routes them to dedicated Virtual Texture parameters, and displays tile counts inline in the Preview window (`[UDIM: 6 Tiles]`). 
 
+* **🏺 Atlas & Modular Kit Detection**: Automatically detects kit-based asset groups using hyphen delimiters (e.g. `SM_Rock01-RockKit.fbx`). Unifies all kit meshes under a flat folder (`/Game/Environment/RockKit/`), cleans asset names on import (`SM_Rock01`), shares a single Material Instance (`MI_RockKit`) across all meshes at slot 0, and badges kit summaries in the Preview UI (`[Atlas: X Meshes]`).
+
 
 ---
 

--- a/asset_port/Validator.py
+++ b/asset_port/Validator.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from asset_port.models import AssetType, AssetGroup, TextureSlot,DetectedAsset
+from asset_port.models import AssetType, AssetGroup, TextureSlot,DetectedAsset, AtlasGroup
 
 def asset_validator(asset : DetectedAsset ):
     
@@ -53,5 +53,31 @@ def group_validator(group : AssetGroup):
     if TextureSlot.ROUGHNESS not in found_texture and TextureSlot.ORM not in found_texture:
         warnings.append(f"group {group.base_name} Roughness or ORM map is missing ") 
         
+        
+    return warnings
+
+def atlas_group_validator(group: AtlasGroup):
+    
+    warnings = []
+    found_texture = []
+    textures = group.texture_list
+    
+    for texture in textures:
+        found_texture.append(texture.texture_slot)
+        
+    if group.mesh_count >= 1 and len(found_texture) == 0:
+        warnings.append(f"group {group.kit_name} has no textures")
+        
+    if TextureSlot.BASE_COLOUR not in found_texture:
+        warnings.append(f"group {group.kit_name} base colour map is missing")
+            
+    if TextureSlot.NORMAL not in found_texture:
+        warnings.append(f"group {group.kit_name} Normal map is missing")
+            
+    if TextureSlot.ROUGHNESS not in found_texture and TextureSlot.ORM not in found_texture:
+        warnings.append(f"group {group.kit_name} Roughness or ORM map is missing ") 
+        
+    if group.mesh_count== 1:
+        warnings.append(f"group {group.kit_name} has only one mesh")
         
     return warnings

--- a/asset_port/detector.py
+++ b/asset_port/detector.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from .models import AssetType, TextureSlot, DetectedAsset, AssetGroup
+from .models import AssetType, TextureSlot, DetectedAsset, AssetGroup, AtlasGroup
 import re
 
 PREFIX_MAP = {
@@ -199,3 +199,47 @@ class AssetDetector:
         
         return list(groups.values())
             
+            
+    def group_atlas_assets(self, assets: list[DetectedAsset]) -> tuple[list[AtlasGroup], list[DetectedAsset]]:
+        
+        kit_meshes ={}
+        
+        for asset in assets:
+            if asset.kit_name:
+                if asset.kit_name not in kit_meshes:
+                    kit_meshes[asset.kit_name] = []
+                kit_meshes[asset.kit_name].append(asset)
+                
+        
+        kit_textures = {}
+        
+        remaining = []
+        
+        for asset in assets:
+            if asset.kit_name:
+                continue
+            
+            if asset.asset_type == AssetType.TEXTURE and asset.base_name in kit_meshes:
+                
+                if asset.base_name not in kit_textures:
+                    kit_textures[asset.base_name] = []
+                kit_textures[asset.base_name].append(asset)
+                
+            else:
+                remaining.append(asset)
+                
+                
+        atlas_group = []
+        
+        for kit_name, meshes in kit_meshes.items():
+            group = AtlasGroup(
+                kit_name=kit_name,
+                mesh_list=meshes,
+                texture_list=kit_textures.get(kit_name,[]),
+                category=meshes[0].category,
+            )
+            atlas_group.append(group)
+            
+        return atlas_group, remaining
+                
+                

--- a/asset_port/detector.py
+++ b/asset_port/detector.py
@@ -113,9 +113,18 @@ class AssetDetector:
         category_raw = group.get("category")
         category_str = category_raw.lower() if category_raw else ""
         
-        base_name = group.get("base")
+        parsed_name = group.get("base")
         material_raw = group.get("material")
         suffix_raw = group.get("suffix")
+        
+        kit_name = ""
+        ue_asset_name = ""
+        
+        if "-" in parsed_name and prefix in ("sm", "sk"):
+            parts = parsed_name.rsplit("-", 1)
+            individual_name = parts[0]
+            kit_name =parts[1]
+            ue_asset_name = f"{prefix}_{individual_name}"
         
         if material_raw and not suffix_raw:
             if material_raw.lower() in SUFFIX_MAP:
@@ -139,14 +148,16 @@ class AssetDetector:
             filename=path_obj.name,
             source_path=str(path_obj.as_posix()),
             prefix=prefix,
-            base_name = base_name or stem,
+            base_name = parsed_name,
             suffix= suffix,
             asset_type= asset_type,
             texture_slot= texture_slot,
             extension= path_obj.suffix,
             category=category,
             material_slot_name=material_slot_name,
-            udim_tile=udim_tile
+            udim_tile=udim_tile,
+            kit_name=kit_name,
+            ue_asset_name=ue_asset_name
         )
         
 

--- a/asset_port/detector.py
+++ b/asset_port/detector.py
@@ -124,7 +124,7 @@ class AssetDetector:
             parts = parsed_name.rsplit("-", 1)
             individual_name = parts[0]
             kit_name =parts[1]
-            ue_asset_name = f"{prefix}_{individual_name}"
+            ue_asset_name = f"{prefix.upper()}_{individual_name}"
         
         if material_raw and not suffix_raw:
             if material_raw.lower() in SUFFIX_MAP:

--- a/asset_port/gui_helper.py
+++ b/asset_port/gui_helper.py
@@ -4,7 +4,7 @@ from tkinter import filedialog
 from asset_port.importer import AssetImporter
 from asset_port.logger import log_pipeline_report
 from asset_port.config import config_loader
-from asset_port.models import TextureSlot
+from asset_port.models import TextureSlot, AtlasGroup, AssetGroup
 active_widget = None
 preview_widget = None
 last_folder_path = ""
@@ -19,8 +19,10 @@ TRANSPARENCY_ID = unreal.Name("/Game/Python/Widgets/EUW_TransparencySetup.EUW_Tr
 def scan_for_transparency(groups):
     items = []
     for group in groups:
-        if group.is_multi_material:
+        if isinstance(group, AssetGroup) and group.is_multi_material:
             slot_to_scan = {f"MI_{group.base_name}_{slot}": texs for slot, texs in group.material_slots.items()}
+        elif isinstance(group, AtlasGroup):
+            slot_to_scan = {f"MI_{group.kit_name}" : group.texture_list}
         else:
             slot_to_scan = {f"MI_{group.base_name}": group.texture_list}
             
@@ -237,23 +239,31 @@ def on_preview_clicked():
             display_folder = group.folder_path
             if display_folder.startswith("/Game/"):
                 display_folder = display_folder[6:]
-            if group.mesh is not None:
+            if isinstance(group, AtlasGroup):
+                display_folder = f"{display_folder}  [Atlas: {group.mesh_count} Meshes]"  
+            if isinstance(group, AssetGroup) and  group.mesh is not None:
                 mesh_name = group.mesh.ue_path.split("/")[-1]
                 import_asset_name.append(f"{display_folder}|{mesh_name}")
+            elif isinstance(group, AtlasGroup):
+                for mesh in group.mesh_list:
+                    mesh_name = mesh.ue_path.split("/")[-1]
+                    import_asset_name.append(f"{display_folder}|{mesh_name}")
             for texture in group.texture_list:
                 texture_name = texture.ue_path.split("/")[-1]
                 if texture.is_udim:
                     padded_name= texture_name.ljust(pad_width)
                     texture_name = f"{padded_name}[UDIM: {texture.tile_count} Tiles]"
-                if group.is_multi_material:
+                if isinstance(group, AssetGroup) and group.is_multi_material:
                     import_asset_name.append(f"{display_folder}|Textures/{texture_name}")
                 else:
                     import_asset_name.append(f"{display_folder}|{texture_name}")
         
             if config.auto_create_mi:
-                if group.is_multi_material:
+                if isinstance(group, AssetGroup) and group.is_multi_material:
                     for slot_name in group.material_slots.keys():
                         import_asset_name.append(f"{display_folder}|Materials/MI_{group.base_name}_{slot_name}")
+                elif isinstance(group, AtlasGroup):
+                    import_asset_name.append(f"{display_folder}|MI_{group.kit_name}")
                 else:
                     import_asset_name.append(f"{display_folder}|MI_{group.base_name}")   
                 

--- a/asset_port/importer.py
+++ b/asset_port/importer.py
@@ -3,10 +3,10 @@ from pathlib import Path
 from asset_port.detector import AssetDetector
 from asset_port.router import AssetRouter
 from asset_port.presets import get_mesh_setting, texture_settings
-from asset_port.models import AssetType, PipelineReport, TextureSlot
-from asset_port.Validator import asset_validator, group_validator
+from asset_port.models import AssetType, PipelineReport, TextureSlot, AtlasGroup
+from asset_port.Validator import asset_validator, group_validator, atlas_group_validator
 from asset_port.config import config_loader
-from asset_port.materials import create_material_instance
+from asset_port.materials import create_material_instance,create_atlas_material_instance
 
 def check_source_has_alpha(file_path):
     if not file_path:
@@ -81,13 +81,10 @@ class AssetImporter():
         file_path = Path(source_dir)
         tasks = []
         detect_group = []
-        
         for file in file_path.rglob("*"):
-            
             if file.is_dir():
                 continue
             report.total_scanned += 1
-             
             detected_asset = self.detector.detect_file(file)
             
             if detected_asset is None:
@@ -96,64 +93,68 @@ class AssetImporter():
             validator = asset_validator(detected_asset )
             warnings, errors = validator
             
-            
-            router_asset = self.router.get_folder_path(detected_asset, category)
-            folder, asset = router_asset
-            
-            detected_asset.ue_path = asset
             if  len(errors) > 0 :
                 report.errors.extend(errors)
                 report.asset_failed += 1
                 continue
-            
+                        
             if len(warnings) > 0:
                 report.warnings.extend(warnings)
-                
-            detect_group.append(detected_asset)   
             
-            if detected_asset.is_udim and not detected_asset.is_udim_primary:
-                continue
+            detect_group.append(detected_asset)
         
-            asset_name = asset.split("/")[-1]
-            if not dry_run:
-                
-                task = unreal.AssetImportTask()  
-                task.filename = detected_asset.source_path
-                task.destination_path = folder
-                task.destination_name = asset_name
-                task.automated = True
-                task.save = True
-            
-                if detected_asset.extension.lower() == ".fbx" or detected_asset.asset_type in (AssetType.STATIC_MESH, AssetType.SKELETAL_MESH):
-                    task.options = get_mesh_setting(detected_asset)
-            
-                tasks.append(task) 
-            
-        if not dry_run:      
-            imported_objects = unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks(tasks)
-        
-        for asset, task in zip(detect_group, tasks):
-            imported_objs = task.get_objects()
-            if not imported_objs:
-                continue
-            for obj in imported_objs:
-                current_path = obj.get_package().get_name()
-                if current_path != asset.ue_path:
-                    unreal.EditorAssetLibrary.rename_asset(current_path, asset.ue_path)
         group_asset = self.detector.group_assets(detect_group)
         
         for group in group_asset:
+            assets_in_group = group.texture_list.copy()
+            if group.mesh:
+                assets_in_group.append(group.mesh)
+                
+            for asset in assets_in_group: 
+                folder, asset_path = self.router.get_folder_path(asset, category)
+                asset.ue_path = asset_path
+                if asset.is_udim and not asset.is_udim_primary:
+                    continue
+                
+                asset_name = asset.ue_path.split("/")[-1]
+                if not dry_run:
+                        
+                    task = unreal.AssetImportTask()  
+                    task.filename = asset.source_path
+                    task.destination_path = folder
+                    task.destination_name = asset_name
+                    task.automated = True
+                    task.save = True
+                    
+                    if asset.extension.lower() == ".fbx" or asset.asset_type in (AssetType.STATIC_MESH, AssetType.SKELETAL_MESH):
+                        task.options = get_mesh_setting(asset)
+                
+                    tasks.append(task) 
+            
             ref_asset = group.mesh or (group.texture_list[0] if group.texture_list else None)
             if ref_asset and ref_asset.ue_path:
                 folder_parts = ref_asset.ue_path.split("/")[:-1]
                 if folder_parts and folder_parts[-1] == "Textures":
                     folder_parts = folder_parts[:-1]
                 group.folder_path = "/".join(folder_parts)   
-                
+                        
                 group_warnings = group_validator(group)
                 if group_warnings:
                     report.warnings.extend(group_warnings)
-                           
+        
+        if not dry_run:      
+            imported_objects = unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks(tasks)
+                            
+            for asset, task in zip(detect_group, tasks):
+                imported_objs = task.get_objects()
+                if not imported_objs:
+                    continue
+                for obj in imported_objs:
+                    current_path = obj.get_package().get_name()
+                    if current_path != asset.ue_path:
+                        unreal.EditorAssetLibrary.rename_asset(current_path, asset.ue_path)
+            
+        
         report.groups_found = len(group_asset)
         if dry_run:
             report.asset_import = len(detect_group)
@@ -185,7 +186,6 @@ class AssetImporter():
                             asset.has_alpha = check_source_has_alpha(asset.source_path)
                             unreal.log(f"AssetPort: BaseColour {asset.base_name} has_alpha -> {asset.has_alpha}")
                     
-           
         successful_imports = 0
         for task in tasks:
             if len(task.get_objects()) >0:

--- a/asset_port/importer.py
+++ b/asset_port/importer.py
@@ -82,7 +82,7 @@ class AssetImporter():
     def import_directory(self, source_dir, category, dry_run = False):
         report = PipelineReport()
         file_path = Path(source_dir)
-        tasks = []
+        task_pairs = []
         detect_group = []
         for file in file_path.rglob("*"):
             if file.is_dir():
@@ -129,7 +129,7 @@ class AssetImporter():
                     if mesh.extension.lower() == ".fbx" or mesh.asset_type in (AssetType.STATIC_MESH, AssetType.SKELETAL_MESH):
                         task.options = get_mesh_setting(mesh)
                                     
-                    tasks.append(task)
+                    task_pairs.append((mesh, task))
             for texture in atlas_group.texture_list:
                 folder, asset_path = self.router.get_atlas_folder_path(texture, atlas_group,category)
                 texture.ue_path = asset_path
@@ -144,7 +144,7 @@ class AssetImporter():
                     task.automated = True
                     task.save = True
                                                             
-                    tasks.append(task)
+                    task_pairs.append((texture, task))
             atlas_warnings = atlas_group_validator(atlas_group)
             if atlas_warnings:
                 report.warnings.extend(atlas_warnings)
@@ -173,7 +173,7 @@ class AssetImporter():
                     if asset.extension.lower() == ".fbx" or asset.asset_type in (AssetType.STATIC_MESH, AssetType.SKELETAL_MESH):
                         task.options = get_mesh_setting(asset)
                 
-                    tasks.append(task) 
+                    task_pairs.append((asset, task)) 
             
             ref_asset = group.mesh or (group.texture_list[0] if group.texture_list else None)
             if ref_asset and ref_asset.ue_path:
@@ -186,10 +186,11 @@ class AssetImporter():
                 if group_warnings:
                     report.warnings.extend(group_warnings)
         
-        if not dry_run:      
-            imported_objects = unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks(tasks)
+        if not dry_run:   
+            unreal_tasks = [t for a, t in task_pairs]   
+            imported_objects = unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks(unreal_tasks)
                             
-            for asset, task in zip(detect_group, tasks):
+            for asset, task in task_pairs:
                 imported_objs = task.get_objects()
                 if not imported_objs:
                     continue
@@ -216,7 +217,7 @@ class AssetImporter():
             slow_task.make_dialog(True)
                 
     
-            for asset, task in zip(detect_group, tasks):
+            for asset, task in task_pairs:
                 if slow_task.should_cancel():
                     break
             
@@ -233,7 +234,7 @@ class AssetImporter():
                             unreal.log(f"AssetPort: BaseColour {asset.base_name} has_alpha -> {asset.has_alpha}")
                     
         successful_imports = 0
-        for task in tasks:
+        for asset, task in task_pairs:
             if len(task.get_objects()) >0:
                 successful_imports += 1
                 

--- a/asset_port/importer.py
+++ b/asset_port/importer.py
@@ -200,6 +200,8 @@ class AssetImporter():
             
         
         report.groups_found = len(group_asset) + len(atlas_groups)
+        report.atlas_group_found = len(atlas_groups)
+        report.atlas_meshes_imported = sum(g.mesh_count for g in atlas_groups)
         if dry_run:
             report.asset_import = len(detect_group)
             if self.config.auto_create_mi:

--- a/asset_port/importer.py
+++ b/asset_port/importer.py
@@ -70,7 +70,10 @@ class AssetImporter():
         
     def build_materials(self, group_asset, decisions=None, report= None):
         for group in group_asset:
-            mi_report = create_material_instance(group, self.config, decisions)
+            if isinstance(group, AtlasGroup):
+                mi_report = create_atlas_material_instance(group, self.config, decisions)
+            else:
+                mi_report = create_material_instance(group, self.config, decisions)
             if report and mi_report.success:
                 report.mis_created += 1
                 if mi_report.mesh_linked:
@@ -103,8 +106,49 @@ class AssetImporter():
             
             detect_group.append(detected_asset)
         
-        group_asset = self.detector.group_assets(detect_group)
+        atlas_groups, remianing_assets = self.detector.group_atlas_assets(detect_group)
+        group_asset = self.detector.group_assets(remianing_assets)
         
+        all_group = atlas_groups + group_asset
+        
+        for atlas_group in atlas_groups:
+            for mesh in atlas_group.mesh_list:
+                folder, asset_path = self.router.get_atlas_folder_path(mesh, atlas_group,category)
+                mesh.ue_path = asset_path
+                atlas_group.folder_path = folder
+                
+                mesh_name = mesh.ue_path.split("/")[-1]
+                if not dry_run:
+                    task = unreal.AssetImportTask()  
+                    task.filename = mesh.source_path
+                    task.destination_path = folder
+                    task.destination_name = mesh_name
+                    task.automated = True
+                    task.save = True
+                                        
+                    if mesh.extension.lower() == ".fbx" or mesh.asset_type in (AssetType.STATIC_MESH, AssetType.SKELETAL_MESH):
+                        task.options = get_mesh_setting(mesh)
+                                    
+                    tasks.append(task)
+            for texture in atlas_group.texture_list:
+                folder, asset_path = self.router.get_atlas_folder_path(texture, atlas_group,category)
+                texture.ue_path = asset_path
+                if texture.is_udim and not texture.is_udim_primary:
+                    continue
+                texture_name = texture.ue_path.split("/")[-1]
+                if not dry_run:
+                    task = unreal.AssetImportTask()  
+                    task.filename = texture.source_path
+                    task.destination_path = folder
+                    task.destination_name = texture_name
+                    task.automated = True
+                    task.save = True
+                                                            
+                    tasks.append(task)
+            atlas_warnings = atlas_group_validator(atlas_group)
+            if atlas_warnings:
+                report.warnings.extend(atlas_warnings)
+                    
         for group in group_asset:
             assets_in_group = group.texture_list.copy()
             if group.mesh:
@@ -155,16 +199,16 @@ class AssetImporter():
                         unreal.EditorAssetLibrary.rename_asset(current_path, asset.ue_path)
             
         
-        report.groups_found = len(group_asset)
+        report.groups_found = len(group_asset) + len(atlas_groups)
         if dry_run:
             report.asset_import = len(detect_group)
             if self.config.auto_create_mi:
-                report.mis_created = len(group_asset)
+                report.mis_created = len(group_asset) + len(atlas_groups)
                 report.mis_linked = sum(1 for g in group_asset if g.mesh is not None)
         
-            return group_asset, report    
+            return all_group, report    
             
-        total_steps = len(detect_group) + (len(group_asset) if self.config.auto_create_mi else 0)
+        total_steps = len(detect_group) + (len(all_group) if self.config.auto_create_mi else 0)
         
         with unreal.ScopedSlowTask(total_steps, "Processing Imported assets...") as slow_task:
             slow_task.make_dialog(True)
@@ -196,4 +240,4 @@ class AssetImporter():
         
         report.asset_import = successful_imports
         
-        return group_asset, report 
+        return all_group, report 

--- a/asset_port/logger.py
+++ b/asset_port/logger.py
@@ -9,6 +9,7 @@ def log_pipeline_report(report: PipelineReport, selected_path :str, dry_run = Fa
         unreal.log("===================================================")
         unreal.log(f"Scanned: {report.total_scanned}")
         unreal.log(f"would create MIs : {report.mis_created}")
+        unreal.log(f"Atlas Groups: {report.atlas_group_found}")
         unreal.log("===================================================")
         if report.warnings:
             for warning in report.warnings:
@@ -21,6 +22,7 @@ def log_pipeline_report(report: PipelineReport, selected_path :str, dry_run = Fa
         unreal.log("===================================================")
         unreal.log(f"Scanned: {report.total_scanned} | Imported: {report.asset_import}")
         unreal.log(f"MIs Created: {report.mis_created} | MIs Linked: {report.mis_linked}")
+        unreal.log(f"Atlas Groups: {report.atlas_group_found}")
         unreal.log("===================================================")
         if report.warnings:
             for warning in report.warnings:
@@ -50,6 +52,7 @@ def log_pipeline_report(report: PipelineReport, selected_path :str, dry_run = Fa
             f.write("AssetPort Import report\n")
             f.write(f"Scanned: {report.total_scanned}\n")
             f.write(f"Imported: {report.asset_import}\n")
+            f.write(f"Atlas Meshes imported: {report.atlas_meshes_imported}\n")
         
             if report.warnings:
                 for warning in report.warnings:

--- a/asset_port/materials.py
+++ b/asset_port/materials.py
@@ -146,9 +146,9 @@ def create_atlas_material_instance(group_atlas: AtlasGroup, config: ImporterSett
         
     
     
-    mi_name = group_atlas.kit_name
+    mi_name = f"MI_{group_atlas.kit_name}"
     mi_folder = group_atlas.folder_path 
-    mi_path =f"{mi_folder}/MI_{mi_name}"
+    mi_path =f"{mi_folder}/{mi_name}"
             
     blend_mode = decisions.get(mi_name, "Opaque") if decisions else "Opaque"
             
@@ -176,6 +176,8 @@ def create_atlas_material_instance(group_atlas: AtlasGroup, config: ImporterSett
             asset_class=unreal.MaterialInstanceConstant,
             factory=factory
             )
+        
+    mi.set_editor_property("parent", parent_material)
             
             
     textures = group_atlas.texture_list
@@ -246,4 +248,5 @@ def create_atlas_material_instance(group_atlas: AtlasGroup, config: ImporterSett
             unreal.EditorAssetLibrary.save_loaded_asset(mesh_object)
             material_report.mesh_linked = group_atlas.kit_name
         
+    material_report.success = True
     return material_report

--- a/asset_port/materials.py
+++ b/asset_port/materials.py
@@ -1,5 +1,5 @@
 import unreal
-from asset_port.models import AssetGroup , MaterialBuildResult, TextureSlot
+from asset_port.models import AssetGroup , MaterialBuildResult, TextureSlot, AtlasGroup
 from asset_port.config import ImporterSettings
 
 def create_material_instance(group : AssetGroup, config: ImporterSettings, decisions: dict = None):
@@ -135,3 +135,115 @@ def create_material_instance(group : AssetGroup, config: ImporterSettings, decis
     material_report.success = True
     return material_report
     
+def create_atlas_material_instance(group_atlas: AtlasGroup, config: ImporterSettings, decisions: dict = None):
+    
+    folder_path = group_atlas.folder_path
+       
+    material_report = MaterialBuildResult(base_name=group_atlas.kit_name)
+    mesh_objects = []
+    for mesh_object in group_atlas.mesh_list:
+        mesh_objects.append(unreal.EditorAssetLibrary.load_asset(mesh_object.ue_path) if mesh_object else None)
+        
+    
+    
+    mi_name = group_atlas.kit_name
+    mi_folder = group_atlas.folder_path 
+    mi_path =f"{mi_folder}/MI_{mi_name}"
+            
+    blend_mode = decisions.get(mi_name, "Opaque") if decisions else "Opaque"
+            
+    if blend_mode =="Masked":
+        m_master = config.parent_material_masked
+    elif blend_mode == "Translucent":
+        m_master = config.parent_material_translucent
+    else:
+        m_master = config.parent_material_opaque
+            
+    parent_material = unreal.EditorAssetLibrary.load_asset(m_master)
+    
+    mi = None
+    if unreal.EditorAssetLibrary.does_asset_exist(mi_path):
+        if not config.replace_existing:
+            mi = unreal.EditorAssetLibrary.load_asset(mi_path)
+        else:
+            unreal.EditorAssetLibrary.delete_asset(mi_path)
+                    
+    if mi is None:
+        factory = unreal.MaterialInstanceConstantFactoryNew()
+        mi = unreal.AssetToolsHelpers.get_asset_tools().create_asset(
+            asset_name=mi_name,
+            package_path=mi_folder,
+            asset_class=unreal.MaterialInstanceConstant,
+            factory=factory
+            )
+            
+            
+    textures = group_atlas.texture_list
+            
+    if blend_mode in ("Masked", "Translucent"):
+        base_color_tex = next((t for t in textures if t.texture_slot == TextureSlot.BASE_COLOUR),None)
+        use_alpha = base_color_tex.has_alpha if base_color_tex else False
+                
+        unreal.MaterialEditingLibrary.set_material_instance_static_switch_parameter_value(
+                mi,
+                "UseBaseColourAlpha",
+                value=use_alpha
+                )
+                
+    has_vt = False
+    for texture in textures:
+        if not texture.ue_path:
+            continue
+        tex_obj = unreal.EditorAssetLibrary.load_asset(texture.ue_path)
+        if tex_obj and tex_obj.get_editor_property("virtual_texture_streaming"):
+            has_vt = True
+            break
+                
+    unreal.MaterialEditingLibrary.set_material_instance_static_switch_parameter_value(
+        mi,
+        "UseVT",
+        value=has_vt,
+        )
+            
+    for texture in textures:
+        if not texture.ue_path:
+            continue
+        texture_object = unreal.EditorAssetLibrary.load_asset(texture.ue_path)
+                
+        if has_vt and not texture_object.get_editor_property("virtual_texture_streaming"):
+            texture_object.set_editor_property("virtual_texture_streaming", True)
+            unreal.EditorAssetLibrary.save_loaded_asset(texture_object)
+                    
+        param_name = texture.texture_slot.value
+        if texture.texture_slot == TextureSlot.OPACITY_MASK:
+            param_name = "OpacityMask"
+        elif texture.texture_slot == TextureSlot.OPACITY:
+            param_name = "Opacity"
+                    
+        if has_vt:
+            param_name = f"{param_name}_VT"
+                
+        unreal.MaterialEditingLibrary.set_material_instance_texture_parameter_value(
+            mi,
+            param_name,
+            texture_object
+            )
+                
+        if texture.texture_slot == TextureSlot.ORM:
+            unreal.MaterialEditingLibrary.set_material_instance_static_switch_parameter_value(
+                mi,
+                "UseORM",
+                value=True
+                )
+                
+        material_report.texture_assigned[param_name] = texture.ue_path
+            
+    unreal.EditorAssetLibrary.save_loaded_asset(mi)
+        
+    for mesh_object in mesh_objects:
+        if mesh_object:
+            mesh_object.set_material(0,mi)
+            unreal.EditorAssetLibrary.save_loaded_asset(mesh_object)
+            material_report.mesh_linked = group_atlas.kit_name
+        
+    return material_report

--- a/asset_port/models.py
+++ b/asset_port/models.py
@@ -99,6 +99,8 @@ class PipelineReport:
     asset_failed : int =0
     mis_created : int =0
     mis_linked : int = 0
+    atlas_group_found : int =0
+    atlas_meshes_imported : int =0
     warnings : list[str] = field(default_factory=list)
     errors  : list[str] = field(default_factory=list)
     

--- a/asset_port/models.py
+++ b/asset_port/models.py
@@ -40,6 +40,8 @@ class DetectedAsset:
     material_slot_name : Optional[str] = None
     udim_tile : Optional[str] = None
     tile_count : int = 1
+    kit_name: Optional[str] = None
+    ue_asset_name: Optional[str] = None
     @property
     def is_udim(self) -> bool:
         return self.udim_tile is not None
@@ -59,10 +61,20 @@ class AssetGroup:
     @property
     def is_multi_material(self) -> bool:
         return len(self.material_slots) > 1
+ 
+@dataclass
+class AtlasGroup:
+    kit_name: str
+    mesh_list: list[DetectedAsset] = field(default_factory=list)
+    texture_list: list[DetectedAsset] = field(default_factory=list)
+    category : Optional[str] = None
+    folder_path: Optional[str] = None   
     
+    @property
+    def mesh_count(self) -> int:
+        return len(self.mesh_list)
     
-    
-    
+        
 @dataclass
 class ImportResult:
     asset : DetectedAsset

--- a/asset_port/router.py
+++ b/asset_port/router.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from asset_port.detector import AssetDetector 
-from asset_port.models import DetectedAsset, AssetType
+from asset_port.models import DetectedAsset, AssetType, AtlasGroup
 from typing import Optional
 class AssetRouter():
     
@@ -55,6 +55,51 @@ class AssetRouter():
         asset_path = f"{folder_path}/{asset_name}"        
             
         return folder_path, asset_path
+        
+    def get_atlas_folder_path(self, asset: DetectedAsset ,atlas_group: AtlasGroup, category_override: Optional[str] = None):
+        if category_override:
+            category = category_override
+          
+        elif atlas_group.category:
+            category = atlas_group.category
+                   
+        else:
+            file_path =asset.source_path
+                    
+            path_lower = file_path.lower()
+                    
+            if "weapon" in path_lower or "wpn" in path_lower:
+                category = "Weapon"
+                       
+            elif "environment" in path_lower or "env" in path_lower:
+                category = "Environment"
+                        
+            elif "props" in path_lower or "prop" in path_lower:
+                category = "Props"
+                        
+            elif "character" in path_lower or "char" in path_lower:
+                category = "Character"
+                        
+            else:
+                category = "_Unsorted"
+       
+         
+        folder_path = f"/Game/{category}/{atlas_group.kit_name}"
+        asset_name = ""
+        if asset.asset_type in (AssetType.STATIC_MESH, AssetType.SKELETAL_MESH):
+            asset_name = asset.ue_asset_name
+            
+        elif asset.asset_type == AssetType.TEXTURE:
+            prefix = f"{asset.prefix.upper()}_" if asset.prefix else ""
+            suffix = f"_{asset.suffix}" if asset.suffix else ""
+            asset_name = f"{prefix}{asset.base_name}{suffix}"
+            
+        asset_path = f"{folder_path}/{asset_name}"
+        
+        return folder_path, asset_path
+        
+        
+            
         
     
             


### PR DESCRIPTION
### How Atlas Kit Detection & Import Works:

1. **Naming Convention:** 
   * Meshes use a hyphen for the kit name: `SM_env_Rock01-RockKit.fbx`
   * Textures use the kit base name: `T_env_RockKit_D.png`, `T_env_RockKit_N.png`

2. **Grouping & Detection:**
   * The parser extracts `Rock01` as the mesh name and `RockKit` as the shared kit.
   * `group_atlas_assets()` bundles multiple meshes with the shared texture set into a single `AtlasGroup`.

3. **Routing & Clean Renaming:**
   * Routes all assets flat into `/Game/{Category}/{KitName}/`.
   * Automatically strips the kit suffix in Unreal (`SM_Rock01-RockKit.fbx` $\rightarrow$ `SM_Rock01`).

4. **Shared Material Instance:**
   * Generates a single `MI_RockKit` and assigns it to Slot 0 across all meshes in the kit.