### PR TITLE
Support prefixless marketplace asset names and additional map suffixes

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -40,7 +40,9 @@ Prefixes tell the tool what type of asset is being imported. This is case-insens
 | `t_` | Texture | `unreal.Texture2D` |
 | `a_` | Animation | `unreal.AnimSequence` |
 
-*If no prefix is found, the asset type defaults to `Unknown` and will not be automated.*
+*If no prefix is found, supported image extensions are inferred as textures and
+`.fbx` files are inferred as static meshes. Explicit prefixes still take
+priority and should be used for skeletal meshes and animations.*
 
 ---
 
@@ -70,11 +72,20 @@ Suffixes determine how textures are mapped inside the created **Material Instanc
 | `_n`, `_nrm`, `_normal` | **Normal** | `False` | `TC_Normalmap` |
 | `_r`, `_roughness`, `_rough` | **Roughness** | `False` | `TC_Masks` |
 | `_m`, `_metal`, `_metallic` | **Metallic** | `False` | `TC_Masks` |
+| `_metalness` | **Metallic** | `False` | `TC_Masks` |
 | `_ao`, `_ambientocclusion` | **AmbientOcclusion** (AO) | `False` | `TC_Masks` |
+| `_cavity` | **Cavity** | `False` | `TC_Masks` |
 | `_e`, `_emissive` | **Emissive** | `True` | `TC_Default` |
-| `_o`, `_opacity`, `_mask`, `_opacitymask` | **Opacity / Mask** | `False` | `TC_Alpha` |
-| `_h`, `_height`, `_disp`, `_displacement`  | **Height** | `False` | `TC_Masks` |
+| `_o`, `_opacity` | **Opacity** | `False` | `TC_Alpha` |
+| `_mask`, `_opacitymask` | **Opacity Mask** | `False` | `TC_Masks` |
+| `_specular`, `_gloss` | **Specular / Gloss** | `False` | `TC_Masks` |
+| `_translucency` | **Translucency** | `True` | `TC_Default` |
+| `_h`, `_height`, `_disp`, `_displacement`, `_bump`  | **Height** | `False` | `TC_Masks` |
 | `_orm` | **ORM** (Occlusion, Roughness, Metallic) | `False` | `TC_Masks` |
+| `_rma` | **RMA** (Roughness, Metallic, Ambient Occlusion) | `False` | `TC_Masks` |
+
+Resolution tokens such as `_2K_` and `_4K_` are treated as metadata rather
+than material-slot names when they appear before a recognized texture suffix.
 
 ### Special Material Features:
 * **ORM Textures:** If an `_orm` texture suffix is detected, the tool automatically turns on the static switch parameter **"UseORM"** in the material instance, allowing you to feed packed maps directly.
@@ -106,10 +117,15 @@ Ensure your Master Material defines texture parameters matching these exact name
 | Roughness | `Roughness` | The roughness map input |
 | Metallic | `Metallic` | The metallic map input |
 | Ambient Occlusion | `AmbientOcclusion` | The AO map input |
+| Cavity | `Cavity` | The cavity map input |
 | Emissive | `Emissive` | The emissive map input |
+| Specular | `Specular` | The specular map input |
+| Gloss | `Gloss` | The gloss map input |
+| Translucency | `Translucency` | The translucency map input |
 | Opacity | `Opacity` | The opacity / transparency input |
 | Height | `Height` | The height / displacement input |
 | ORM | `ORM` | The occlusion, roughness, and metallic packed input |
+| RMA | `RMA` | The roughness, metallic, and ambient-occlusion packed input |
 
 ### Static Switches
 

--- a/asset_port/Validator.py
+++ b/asset_port/Validator.py
@@ -50,7 +50,11 @@ def group_validator(group : AssetGroup):
     if TextureSlot.NORMAL not in found_texture:
         warnings.append(f"group {group.base_name} Normal map is missing")
         
-    if TextureSlot.ROUGHNESS not in found_texture and TextureSlot.ORM not in found_texture:
+    if (
+        TextureSlot.ROUGHNESS not in found_texture
+        and TextureSlot.ORM not in found_texture
+        and TextureSlot.RMA not in found_texture
+    ):
         warnings.append(f"group {group.base_name} Roughness or ORM map is missing ") 
         
         
@@ -74,7 +78,11 @@ def atlas_group_validator(group: AtlasGroup):
     if TextureSlot.NORMAL not in found_texture:
         warnings.append(f"group {group.kit_name} Normal map is missing")
             
-    if TextureSlot.ROUGHNESS not in found_texture and TextureSlot.ORM not in found_texture:
+    if (
+        TextureSlot.ROUGHNESS not in found_texture
+        and TextureSlot.ORM not in found_texture
+        and TextureSlot.RMA not in found_texture
+    ):
         warnings.append(f"group {group.kit_name} Roughness or ORM map is missing ") 
         
     if group.mesh_count== 1:

--- a/asset_port/detector.py
+++ b/asset_port/detector.py
@@ -28,9 +28,11 @@ SUFFIX_MAP ={
     "m" : TextureSlot.METALLIC,
     "metal" : TextureSlot.METALLIC,
     "metallic" : TextureSlot.METALLIC,
+    "metalness" : TextureSlot.METALLIC,
     
     "ao" : TextureSlot.AO,
     "ambientocclusion" : TextureSlot.AO,
+    "cavity" : TextureSlot.CAVITY,
     
     "e" : TextureSlot.EMISSIVE,
     "emissive" : TextureSlot.EMISSIVE,
@@ -40,13 +42,19 @@ SUFFIX_MAP ={
     
     "mask" : TextureSlot.OPACITY_MASK,
     "opacitymask" : TextureSlot.OPACITY_MASK,
+
+    "specular" : TextureSlot.SPECULAR,
+    "gloss" : TextureSlot.GLOSS,
+    "translucency" : TextureSlot.TRANSLUCENCY,
     
     "h" : TextureSlot.HEIGHT,
     "height" : TextureSlot.HEIGHT,
     "disp" : TextureSlot.HEIGHT,
     "displacement" : TextureSlot.HEIGHT,
+    "bump" : TextureSlot.HEIGHT,
     
     "orm" : TextureSlot.ORM,
+    "rma" : TextureSlot.RMA,
 }
 
 
@@ -62,9 +70,10 @@ class AssetDetector:
     
     def __init__(self) -> None:
         
-        prefix_pattern = "|".join(PREFIX_MAP.keys())
-        category_pattern = "|".join(CATEGORY_MAP.keys())
-        suffix_pattern = "|".join(SUFFIX_MAP.keys())
+        # Prefer longer aliases so overlapping names are parsed deterministically.
+        prefix_pattern = "|".join(sorted(PREFIX_MAP.keys(), key=len, reverse=True))
+        category_pattern = "|".join(sorted(CATEGORY_MAP.keys(), key=len, reverse=True))
+        suffix_pattern = "|".join(sorted(SUFFIX_MAP.keys(), key=len, reverse=True))
     
         pattern = (
             rf"^(?:(?P<prefix>{prefix_pattern})_)?"
@@ -90,6 +99,7 @@ class AssetDetector:
             stem = stem[:udim_match.start()]
         
         match = self.regax.match(stem)
+        inferred_type = self._infer_type(path_obj.suffix)
         
         if not match:
             return DetectedAsset(
@@ -98,7 +108,7 @@ class AssetDetector:
                 prefix="",
                 base_name=stem,
                 suffix="",
-                asset_type=AssetType.UNKNOWN,
+                asset_type=inferred_type,
                 texture_slot=None,
                 extension=path_obj.suffix,
                 category=None,
@@ -130,12 +140,18 @@ class AssetDetector:
             if material_raw.lower() in SUFFIX_MAP:
                 suffix_raw = material_raw
                 material_raw = None
+
+        # Marketplace filenames commonly include resolution metadata before the
+        # texture suffix (for example ``Rock_2K_BaseColor``). It is not a
+        # material-slot name and should not split the asset into a separate slot.
+        if material_raw and re.fullmatch(r"\d+[Kk]", material_raw):
+            material_raw = None
                 
         material_slot_name = material_raw if material_raw else None
         suffix = suffix_raw if suffix_raw else ""
             
         
-        asset_type = PREFIX_MAP.get(prefix, AssetType.UNKNOWN)
+        asset_type = PREFIX_MAP.get(prefix, inferred_type)
         
         category = CATEGORY_MAP.get(category_str, None) if category_str else None
         
@@ -162,6 +178,15 @@ class AssetDetector:
         
 
         return detected_asset
+
+    @staticmethod
+    def _infer_type(extension):
+        extension = extension.lower()
+        if extension in (".png", ".tga", ".jpg", ".exr"):
+            return AssetType.TEXTURE
+        if extension == ".fbx":
+            return AssetType.STATIC_MESH
+        return AssetType.UNKNOWN
         
         
     def group_assets(self, assets : list[DetectedAsset]) -> list[AssetGroup]:
@@ -169,6 +194,12 @@ class AssetDetector:
         groups = {}
         
         for asset in assets:
+            if asset.asset_type not in (
+                AssetType.TEXTURE,
+                AssetType.STATIC_MESH,
+                AssetType.SKELETAL_MESH,
+            ):
+                continue
             if asset.base_name not in groups:
                 groups[asset.base_name] = AssetGroup(
                     base_name= asset.base_name,
@@ -241,5 +272,3 @@ class AssetDetector:
             atlas_group.append(group)
             
         return atlas_group, remaining
-                
-                

--- a/asset_port/models.py
+++ b/asset_port/models.py
@@ -16,10 +16,15 @@ class TextureSlot(Enum):
     ROUGHNESS = "Roughness"
     METALLIC = "Metallic"
     AO = "AmbientOcclusion"
+    CAVITY = "Cavity"
     EMISSIVE = "Emissive"
+    SPECULAR = "Specular"
+    GLOSS = "Gloss"
+    TRANSLUCENCY = "Translucency"
     OPACITY = "Opacity"
     OPACITY_MASK = "OpacityMask"
     ORM = "ORM"
+    RMA = "RMA"
     HEIGHT = "Height"
     UNKNOWN = "Unknown"
     
@@ -103,4 +108,3 @@ class PipelineReport:
     atlas_meshes_imported : int =0
     warnings : list[str] = field(default_factory=list)
     errors  : list[str] = field(default_factory=list)
-    

--- a/asset_port/presets.py
+++ b/asset_port/presets.py
@@ -40,13 +40,25 @@ def texture_settings(texture_asset, slot: TextureSlot):
         texture_asset.compression_settings =unreal.TextureCompressionSettings.TC_NORMALMAP
         
         
-    if slot in (TextureSlot.ROUGHNESS, TextureSlot.METALLIC, TextureSlot.AO, TextureSlot.ORM, TextureSlot.HEIGHT):
+    if slot in (
+        TextureSlot.ROUGHNESS,
+        TextureSlot.METALLIC,
+        TextureSlot.AO,
+        TextureSlot.CAVITY,
+        TextureSlot.SPECULAR,
+        TextureSlot.GLOSS,
+        TextureSlot.ORM,
+        TextureSlot.RMA,
+        TextureSlot.HEIGHT,
+        TextureSlot.OPACITY_MASK,
+    ):
         texture_asset.srgb = False
         texture_asset.compression_settings =unreal.TextureCompressionSettings.TC_MASKS
         
     if slot == TextureSlot.OPACITY:
         texture_asset.srgb = False
         texture_asset.compression_settings =unreal.TextureCompressionSettings.TC_ALPHA
-        
-    
-   
+
+    if slot == TextureSlot.TRANSLUCENCY:
+        texture_asset.srgb = True
+        texture_asset.compression_settings =unreal.TextureCompressionSettings.TC_DEFAULT

--- a/tests/test_detector_marketplace.py
+++ b/tests/test_detector_marketplace.py
@@ -1,0 +1,50 @@
+import unittest
+
+from asset_port.detector import AssetDetector
+from asset_port.models import AssetType, TextureSlot
+
+
+class MarketplaceFilenameTests(unittest.TestCase):
+    def setUp(self):
+        self.detector = AssetDetector()
+
+    def test_prefixless_texture_uses_extension_and_ignores_resolution_token(self):
+        asset = self.detector.detect_file("RockCliff_2K_BaseColor.png")
+
+        self.assertEqual(asset.asset_type, AssetType.TEXTURE)
+        self.assertEqual(asset.base_name, "RockCliff")
+        self.assertIsNone(asset.material_slot_name)
+        self.assertEqual(asset.texture_slot, TextureSlot.BASE_COLOUR)
+
+    def test_prefixless_fbx_defaults_to_static_mesh(self):
+        asset = self.detector.detect_file("RockCliff.fbx")
+
+        self.assertEqual(asset.asset_type, AssetType.STATIC_MESH)
+        self.assertEqual(asset.base_name, "RockCliff")
+
+    def test_additional_marketplace_suffixes(self):
+        expected = {
+            "Metalness": TextureSlot.METALLIC,
+            "Cavity": TextureSlot.CAVITY,
+            "Specular": TextureSlot.SPECULAR,
+            "Gloss": TextureSlot.GLOSS,
+            "Translucency": TextureSlot.TRANSLUCENCY,
+            "Bump": TextureSlot.HEIGHT,
+            "RMA": TextureSlot.RMA,
+        }
+
+        for suffix, slot in expected.items():
+            with self.subTest(suffix=suffix):
+                asset = self.detector.detect_file(f"RockCliff_{suffix}.png")
+                self.assertEqual(asset.asset_type, AssetType.TEXTURE)
+                self.assertEqual(asset.texture_slot, slot)
+
+    def test_unknown_files_do_not_create_empty_groups(self):
+        unknown = self.detector.detect_file("notes.txt")
+
+        self.assertEqual(unknown.asset_type, AssetType.UNKNOWN)
+        self.assertEqual(self.detector.group_assets([unknown]), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This extracts the generally useful marketplace filename handling from AssetPort-CN, following Colosyn's invitation to upstream it.

- infer supported prefixless image files as textures and prefixless FBX files as static meshes
- treat resolution tokens such as 2K and 4K as metadata rather than material-slot names
- recognize Metalness, Cavity, Specular, Gloss, Translucency, Bump, and RMA suffixes
- configure suitable texture compression profiles for the additional slots
- ignore unknown files when building asset groups
- document the new conventions

Explicit prefixes still take priority, so skeletal meshes and animations retain the existing naming requirements.

## Verification

- 4 focused unittest cases pass
- audited against a marketplace sample containing 857 files: 86 FBX meshes and 770 textures were classified; the only ignored file was a TXT report

## Scope

This PR intentionally excludes Chinese localization, fallback material generation, and other AssetPort-CN-specific behavior.