### PR TITLE
fix: resolve skeletal mesh import crash and expand naming tokens

### DIFF
--- a/asset_port/detector.py
+++ b/asset_port/detector.py
@@ -5,8 +5,10 @@ import re
 PREFIX_MAP = {
     "sm": AssetType.STATIC_MESH,
     "sk": AssetType.SKELETAL_MESH,
+    "skm": AssetType.SKELETAL_MESH,
     "t": AssetType.TEXTURE,
     "a": AssetType.ANIMATION,
+    "anim": AssetType.ANIMATION,
     }
 
 SUFFIX_MAP ={
@@ -15,7 +17,9 @@ SUFFIX_MAP ={
     "d": TextureSlot.BASE_COLOUR,
     "diffuse" : TextureSlot.BASE_COLOUR,
     "albedo": TextureSlot.BASE_COLOUR,
+    "alb": TextureSlot.BASE_COLOUR,
     "basecolor": TextureSlot.BASE_COLOUR,
+    
     
     "n": TextureSlot.NORMAL,
     "nrm": TextureSlot.NORMAL,
@@ -54,6 +58,8 @@ SUFFIX_MAP ={
     "bump" : TextureSlot.HEIGHT,
     
     "orm" : TextureSlot.ORM,
+    "arm" : TextureSlot.ORM,
+    
     "rma" : TextureSlot.RMA,
 }
 

--- a/asset_port/presets.py
+++ b/asset_port/presets.py
@@ -16,8 +16,7 @@ def get_mesh_setting(asset: DetectedAsset):
         
     elif asset.asset_type == AssetType.SKELETAL_MESH:
       fbx.mesh_type_to_import = unreal.FBXImportType.FBXIT_SKELETAL_MESH  
-      skeletal_mesh = fbx.skeletal_mesh_import_data
-      skeletal_mesh.import_content_type =  unreal.FBXImportContentType.FBXICT_GEOMETRY
+      fbx.import_as_skeletal = True
       
     else:
         fbx.mesh_type_to_import = unreal.FBXImportType.FBXIT_STATIC_MESH


### PR DESCRIPTION
### Summary
- Resolves Python `AttributeError` on `FbxSkeletalMeshImportData.import_content_type` during Skeletal Mesh import by setting `fbx.import_as_skeletal = True`.
- Added support for `skm_` and `anim_` prefixes in `PREFIX_MAP`.
- Added support for `_arm` (packed ORM) and `_alb` (albedo) suffixes in `SUFFIX_MAP`.
Fixes #16