### PR TITLE
Add embedded and separate-file Static Mesh LOD import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+### Added
+- **Static Mesh LOD Import**: Enabled embedded FBX LOD groups and separate `_LOD0`, `_LOD1`, ... files for regular and Atlas Static Mesh assets.
+
 ## [1.5.2] - 2026-08-24
 ### Added
 - **Group Category Inheritance**: Textures in an asset group now automatically inherit the category prefix from the mesh (or vice versa), preventing folder routing desynchronization (Fixes #14).

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -26,6 +26,14 @@ Mesh:    [Prefix]_[Category]_[IndividualName]-[KitName].[extension]
 Texture: [Prefix]_[Category]_[KitName]_[Suffix].[extension]
 ```
 *Example*: `SM_env_Rock01-RockKit.fbx`, `SM_env_Rock02-RockKit.fbx`, `T_env_RockKit_D.png`, `T_env_RockKit_ORM.png`
+
+### Separate Static Mesh LODs:
+```text
+[StaticMeshName]_LOD0.fbx
+[StaticMeshName]_LOD1.fbx
+[StaticMeshName]_LOD2.fbx
+```
+*Example*: `SM_env_Rock_LOD0.fbx`, `SM_env_Rock_LOD1.fbx`. An unsuffixed base mesh such as `SM_env_Rock.fbx` can also be paired with `_LOD1` and later files. Atlas LODs place the marker after the kit name, for example `SM_env_Rock01-RockKit_LOD1.fbx`.
 ---
 
 
@@ -150,3 +158,11 @@ AssetPort supports texture atlas workflows where multiple static meshes share a 
 4. **Flat Folder Routing**: All kit meshes, textures, and the shared Material Instance are placed flat inside `/Game/[Category]/[KitName]/`.
 > [!IMPORTANT]
 > **Hyphen Constraint:** Do not use hyphens (`-`) in standard non-kit asset filenames, as AssetPort treats hyphens as the kit separator.
+
+## 7. Static Mesh LOD Behavior
+
+1. FBX LOD groups embedded in a single file are enabled automatically.
+2. Separately exported files ending in `_LOD0`, `_LOD1`, and later indices are grouped with the base Static Mesh and attached after its import.
+3. An unsuffixed base mesh takes priority if both it and `_LOD0` are present.
+4. Separate-file attachment currently targets Static Meshes; Skeletal Meshes stay on their existing import path.
+5. Set `"auto_import_lods": false` in `importer_config.json` to skip both embedded and separate-file LOD import.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ An automated, pipeline-friendly batch importer and organizer for **Unreal Engine
 * **🧩 UDIM & Virtual Texture Support**: Automatically detects UDIM tile sequences (`_1001` to `_1999`) and 4K Auto-VTs, routes them to dedicated Virtual Texture parameters, and displays tile counts inline in the Preview window (`[UDIM: 6 Tiles]`). 
 
 * **🏺 Atlas & Modular Kit Detection**: Automatically detects kit-based asset groups using hyphen delimiters (e.g. `SM_Rock01-RockKit.fbx`). Unifies all kit meshes under a flat folder (`/Game/Environment/RockKit/`), cleans asset names on import (`SM_Rock01`), shares a single Material Instance (`MI_RockKit`) across all meshes at slot 0, and badges kit summaries in the Preview UI (`[Atlas: X Meshes]`).
+* **📐 Static Mesh LOD Import**: Imports LOD groups embedded in one FBX and attaches separately exported `_LOD0`, `_LOD1`, ... FBX files to regular or Atlas Static Meshes.
 
 
 ---
@@ -93,6 +94,7 @@ You can edit `importer_config.json` inside your project's `Content/Python/` fold
     "master_translucent": "/Game/Python/Materials/M_Master_Translucent",
     "auto_create_mi": true,
     "auto_assign_to_mesh": true,
+    "auto_import_lods": true,
     "replace_existing": false,
     "organize_asset": true
 }
@@ -101,6 +103,7 @@ You can edit `importer_config.json` inside your project's `Content/Python/` fold
 * **`master_opaque` / `master_masked` / `master_translucent`**: Paths to your Master Materials. By default, they point to the included materials under `/Game/Python/Materials/`.
 * **`auto_create_mi`**: Automatically generate a Material Instance for textures.
 * **`auto_assign_to_mesh`**: Link the created Material Instance to the imported mesh.
+* **`auto_import_lods`**: Import embedded FBX LOD groups and attach separate `_LOD#` Static Mesh files.
 * **`replace_existing`**: If true, overwrites any existing Material Instances with the same name.
 
 ---

--- a/asset_port/config.py
+++ b/asset_port/config.py
@@ -11,6 +11,7 @@ class ImporterSettings():
     auto_assign_to_mesh : bool = True
     replace_existing : bool = False
     organize_asset : bool = True
+    auto_import_lods : bool = True
 
 def config_loader():
     

--- a/asset_port/detector.py
+++ b/asset_port/detector.py
@@ -106,7 +106,7 @@ class AssetDetector:
         if path_obj.suffix.lower() == ".fbx":
             lod_match = re.search(r"_LOD(?P<index>\d+)$", stem, re.IGNORECASE)
             if lod_match:
-                lod_index = int(lod_match.group("index"))
+                parsed_index = int(lod_match.group("index"))
                 if parsed_index <= 7:
                     lod_index = parsed_index
                     stem = stem[:lod_match.start()]

--- a/asset_port/detector.py
+++ b/asset_port/detector.py
@@ -107,7 +107,10 @@ class AssetDetector:
             lod_match = re.search(r"_LOD(?P<index>\d+)$", stem, re.IGNORECASE)
             if lod_match:
                 lod_index = int(lod_match.group("index"))
-                stem = stem[:lod_match.start()]
+                if parsed_index <= 7:
+                    lod_index = parsed_index
+                    stem = stem[:lod_match.start()]
+                    # Any index > 7 will leave lod_index =None and prwserve the original stem
         
         udim_tile = None
         udim_match = re.search(r"_(1[0-9]{3})$", stem)

--- a/asset_port/detector.py
+++ b/asset_port/detector.py
@@ -99,6 +99,15 @@ class AssetDetector:
         
         path_obj = Path(file_path)
         stem = path_obj.stem
+
+        # Keep separately exported Mesh_LOD0.fbx, Mesh_LOD1.fbx, ... in the
+        # same asset group without treating the marker as a material token.
+        lod_index = None
+        if path_obj.suffix.lower() == ".fbx":
+            lod_match = re.search(r"_LOD(?P<index>\d+)$", stem, re.IGNORECASE)
+            if lod_match:
+                lod_index = int(lod_match.group("index"))
+                stem = stem[:lod_match.start()]
         
         udim_tile = None
         udim_match = re.search(r"_(1[0-9]{3})$", stem)
@@ -120,7 +129,8 @@ class AssetDetector:
                 texture_slot=None,
                 extension=path_obj.suffix,
                 category=None,
-                material_slot_name=None
+                material_slot_name=None,
+                lod_index=lod_index,
             )
         
         group = match.groupdict()
@@ -181,7 +191,8 @@ class AssetDetector:
             material_slot_name=material_slot_name,
             udim_tile=udim_tile,
             kit_name=kit_name,
-            ue_asset_name=ue_asset_name
+            ue_asset_name=ue_asset_name,
+            lod_index=lod_index,
         )
         
 
@@ -230,7 +241,12 @@ class AssetDetector:
                     group.material_slots[asset.material_slot_name].append(asset)
                 
             elif asset.asset_type in (AssetType.SKELETAL_MESH, AssetType.STATIC_MESH):
-                group.mesh = asset
+                if asset.lod_index in (None, 0):
+                    # Prefer an unsuffixed base mesh if both it and LOD0 exist.
+                    if group.mesh is None or group.mesh.lod_index == 0:
+                        group.mesh = asset
+                else:
+                    group.lod_meshes.append(asset)
                 
             
             if asset.category:
@@ -242,6 +258,8 @@ class AssetDetector:
                     group.mesh.category = group.category
                 for tex in group.texture_list:
                     tex.category = group.category
+                for lod in group.lod_meshes:
+                    lod.category = group.category
         
         return list(groups.values())
             
@@ -249,9 +267,13 @@ class AssetDetector:
     def group_atlas_assets(self, assets: list[DetectedAsset]) -> tuple[list[AtlasGroup], list[DetectedAsset]]:
         
         kit_meshes ={}
+        atlas_lods = {}
         
         for asset in assets:
-            if asset.kit_name:
+            if asset.kit_name and asset.lod_index not in (None, 0):
+                mesh_key = asset.ue_asset_name or asset.base_name
+                atlas_lods.setdefault(asset.kit_name, {}).setdefault(mesh_key, []).append(asset)
+            elif asset.kit_name:
                 if asset.kit_name not in kit_meshes:
                     kit_meshes[asset.kit_name] = []
                 kit_meshes[asset.kit_name].append(asset)
@@ -278,7 +300,12 @@ class AssetDetector:
         atlas_group = []
         
         for kit_name, meshes in kit_meshes.items():
-            all_kit_assets = meshes + kit_textures.get(kit_name, [])
+            lod_assets = [
+                lod
+                for lod_list in atlas_lods.get(kit_name, {}).values()
+                for lod in lod_list
+            ]
+            all_kit_assets = meshes + lod_assets + kit_textures.get(kit_name, [])
             kit_category = next((a.category for a in all_kit_assets if a.category), None)
             
             if kit_category:
@@ -290,6 +317,7 @@ class AssetDetector:
                 mesh_list=meshes,
                 texture_list=kit_textures.get(kit_name,[]),
                 category=kit_category,
+                lod_meshes=atlas_lods.get(kit_name, {}),
             )
             atlas_group.append(group)
             

--- a/asset_port/importer.py
+++ b/asset_port/importer.py
@@ -78,11 +78,59 @@ class AssetImporter():
                 report.mis_created += 1
                 if mi_report.mesh_linked:
                     report.mis_linked += 1
+
+    def _import_static_mesh_lod(self, mesh_asset, lod_asset, report):
+        """Attach a separately exported FBX to an imported Static Mesh LOD."""
+        if not self.config.auto_import_lods:
+            return False
+        if mesh_asset.asset_type != AssetType.STATIC_MESH:
+            report.warnings.append(
+                f"LOD{lod_asset.lod_index} skipped for non-static mesh {mesh_asset.base_name}"
+            )
+            return False
+
+        static_mesh = unreal.EditorAssetLibrary.load_asset(mesh_asset.ue_path)
+        if static_mesh is None:
+            report.errors.append(f"Could not load base mesh for LOD import: {mesh_asset.ue_path}")
+            return False
+
+        result = -1
+        try:
+            subsystem_class = getattr(unreal, "StaticMeshEditorSubsystem", None)
+            subsystem = unreal.get_editor_subsystem(subsystem_class) if subsystem_class else None
+            if subsystem and hasattr(subsystem, "import_lod"):
+                result = subsystem.import_lod(
+                    static_mesh, int(lod_asset.lod_index), lod_asset.source_path
+                )
+            else:
+                legacy = getattr(unreal, "EditorStaticMeshLibrary", None)
+                if legacy and hasattr(legacy, "import_lod"):
+                    result = legacy.import_lod(
+                        static_mesh, int(lod_asset.lod_index), lod_asset.source_path
+                    )
+        except Exception as error:
+            report.errors.append(
+                f"LOD{lod_asset.lod_index} import failed for {mesh_asset.base_name}: {error}"
+            )
+            return False
+
+        success = result if isinstance(result, bool) else result is not None and int(result) >= 0
+        if not success:
+            report.errors.append(
+                f"LOD{lod_asset.lod_index} import failed for {mesh_asset.base_name}"
+            )
+            return False
+
+        lod_asset.ue_path = mesh_asset.ue_path
+        unreal.EditorAssetLibrary.save_loaded_asset(static_mesh)
+        report.lods_imported += 1
+        return True
         
     def import_directory(self, source_dir, category, dry_run = False):
         report = PipelineReport()
         file_path = Path(source_dir)
         task_pairs = []
+        lod_pairs = []
         detect_group = []
         for file in file_path.rglob("*"):
             if file.is_dir():
@@ -127,9 +175,16 @@ class AssetImporter():
                     task.save = True
                                         
                     if mesh.extension.lower() == ".fbx" or mesh.asset_type in (AssetType.STATIC_MESH, AssetType.SKELETAL_MESH):
-                        task.options = get_mesh_setting(mesh)
+                        task.options = get_mesh_setting(mesh, self.config.auto_import_lods)
                                     
                     task_pairs.append((mesh, task))
+                mesh_key = mesh.ue_asset_name or mesh.base_name
+                for lod_asset in sorted(
+                    atlas_group.lod_meshes.get(mesh_key, []),
+                    key=lambda item: item.lod_index,
+                ):
+                    lod_asset.ue_path = asset_path
+                    lod_pairs.append((mesh, lod_asset))
             for texture in atlas_group.texture_list:
                 folder, asset_path = self.router.get_atlas_folder_path(texture, atlas_group,category)
                 texture.ue_path = asset_path
@@ -171,7 +226,7 @@ class AssetImporter():
                     task.save = True
                     
                     if asset.extension.lower() == ".fbx" or asset.asset_type in (AssetType.STATIC_MESH, AssetType.SKELETAL_MESH):
-                        task.options = get_mesh_setting(asset)
+                        task.options = get_mesh_setting(asset, self.config.auto_import_lods)
                 
                     task_pairs.append((asset, task)) 
             
@@ -181,6 +236,11 @@ class AssetImporter():
                 if folder_parts and folder_parts[-1] == "Textures":
                     folder_parts = folder_parts[:-1]
                 group.folder_path = "/".join(folder_parts)   
+
+                if group.mesh:
+                    for lod_asset in sorted(group.lod_meshes, key=lambda item: item.lod_index):
+                        lod_asset.ue_path = group.mesh.ue_path
+                        lod_pairs.append((group.mesh, lod_asset))
                         
                 group_warnings = group_validator(group)
                 if group_warnings:
@@ -205,18 +265,29 @@ class AssetImporter():
         report.atlas_meshes_imported = sum(g.mesh_count for g in atlas_groups)
         if dry_run:
             report.asset_import = len(detect_group)
+            report.lods_imported = len(lod_pairs) if self.config.auto_import_lods else 0
             if self.config.auto_create_mi:
                 report.mis_created = len(group_asset) + len(atlas_groups)
                 report.mis_linked = sum(1 for g in group_asset if g.mesh is not None)
         
             return all_group, report    
             
-        total_steps = len(detect_group) + (len(all_group) if self.config.auto_create_mi else 0)
+        lod_steps = len(lod_pairs) if self.config.auto_import_lods else 0
+        total_steps = len(task_pairs) + lod_steps + (len(all_group) if self.config.auto_create_mi else 0)
         
         with unreal.ScopedSlowTask(total_steps, "Processing Imported assets...") as slow_task:
             slow_task.make_dialog(True)
-                
-    
+
+            if self.config.auto_import_lods:
+                for mesh_asset, lod_asset in lod_pairs:
+                    if slow_task.should_cancel():
+                        break
+                    slow_task.enter_progress_frame(
+                        1,
+                        f"Importing LOD{lod_asset.lod_index}: {mesh_asset.base_name}",
+                    )
+                    self._import_static_mesh_lod(mesh_asset, lod_asset, report)
+
             for asset, task in task_pairs:
                 if slow_task.should_cancel():
                     break
@@ -241,6 +312,6 @@ class AssetImporter():
             if len(task.get_objects()) ==0:
                 report.asset_failed += 1
         
-        report.asset_import = successful_imports
+        report.asset_import = successful_imports + report.lods_imported
         
-        return all_group, report 
+        return all_group, report

--- a/asset_port/importer.py
+++ b/asset_port/importer.py
@@ -285,8 +285,11 @@ class AssetImporter():
                     slow_task.enter_progress_frame(
                         1,
                         f"Importing LOD{lod_asset.lod_index}: {mesh_asset.base_name}",
-                    )
-                    self._import_static_mesh_lod(mesh_asset, lod_asset, report)
+                    ) 
+                    success = self._import_static_mesh_lod(mesh_asset, lod_asset, report)
+                    if not success:
+                        report.warnings.append(f"LOD import failed for {mesh_asset.base_name}, skipping remaining LODs.")
+                        break
 
             for asset, task in task_pairs:
                 if slow_task.should_cancel():

--- a/asset_port/logger.py
+++ b/asset_port/logger.py
@@ -9,7 +9,7 @@ def log_pipeline_report(report: PipelineReport, selected_path :str, dry_run = Fa
         unreal.log("===================================================")
         unreal.log(f"Scanned: {report.total_scanned}")
         unreal.log(f"would create MIs : {report.mis_created}")
-        unreal.log(f"Atlas Groups: {report.atlas_group_found}")
+        unreal.log(f"Atlas Groups: {report.atlas_group_found} | LODs Detected: {report.lods_imported}")
         unreal.log("===================================================")
         if report.warnings:
             for warning in report.warnings:
@@ -22,7 +22,7 @@ def log_pipeline_report(report: PipelineReport, selected_path :str, dry_run = Fa
         unreal.log("===================================================")
         unreal.log(f"Scanned: {report.total_scanned} | Imported: {report.asset_import}")
         unreal.log(f"MIs Created: {report.mis_created} | MIs Linked: {report.mis_linked}")
-        unreal.log(f"Atlas Groups: {report.atlas_group_found}")
+        unreal.log(f"Atlas Groups: {report.atlas_group_found} | LODs Imported: {report.lods_imported}")
         unreal.log("===================================================")
         if report.warnings:
             for warning in report.warnings:
@@ -53,6 +53,7 @@ def log_pipeline_report(report: PipelineReport, selected_path :str, dry_run = Fa
             f.write(f"Scanned: {report.total_scanned}\n")
             f.write(f"Imported: {report.asset_import}\n")
             f.write(f"Atlas Meshes imported: {report.atlas_meshes_imported}\n")
+            f.write(f"LODs imported: {report.lods_imported}\n")
         
             if report.warnings:
                 for warning in report.warnings:
@@ -61,5 +62,4 @@ def log_pipeline_report(report: PipelineReport, selected_path :str, dry_run = Fa
             if report.errors:
                 for error in report.errors:
                     f.write(f"Errors: {error}\n")
-        
         

--- a/asset_port/models.py
+++ b/asset_port/models.py
@@ -47,6 +47,7 @@ class DetectedAsset:
     tile_count : int = 1
     kit_name: Optional[str] = None
     ue_asset_name: Optional[str] = None
+    lod_index: Optional[int] = None
     @property
     def is_udim(self) -> bool:
         return self.udim_tile is not None
@@ -63,6 +64,7 @@ class AssetGroup:
     material_slots : dict[str, list[DetectedAsset]] = field(default_factory=dict)
     category : Optional[str] = None
     folder_path : Optional[str] = None
+    lod_meshes : list[DetectedAsset] = field(default_factory=list)
     @property
     def is_multi_material(self) -> bool:
         return len(self.material_slots) > 1
@@ -74,6 +76,7 @@ class AtlasGroup:
     texture_list: list[DetectedAsset] = field(default_factory=list)
     category : Optional[str] = None
     folder_path: Optional[str] = None   
+    lod_meshes: dict[str, list[DetectedAsset]] = field(default_factory=dict)
     
     @property
     def mesh_count(self) -> int:
@@ -106,5 +109,6 @@ class PipelineReport:
     mis_linked : int = 0
     atlas_group_found : int =0
     atlas_meshes_imported : int =0
+    lods_imported : int = 0
     warnings : list[str] = field(default_factory=list)
     errors  : list[str] = field(default_factory=list)

--- a/asset_port/presets.py
+++ b/asset_port/presets.py
@@ -1,7 +1,7 @@
 import unreal
 from asset_port.models import DetectedAsset, AssetType, TextureSlot
 
-def get_mesh_setting(asset: DetectedAsset):
+def get_mesh_setting(asset: DetectedAsset, import_lods=True):
     
     fbx = unreal.FbxImportUI()
     
@@ -11,6 +11,12 @@ def get_mesh_setting(asset: DetectedAsset):
     if asset.asset_type == AssetType.STATIC_MESH :
         fbx.mesh_type_to_import = unreal.FBXImportType.FBXIT_STATIC_MESH
         static_mesh = fbx.static_mesh_import_data
+        # Import LOD groups embedded in a single FBX. Separate _LOD files are
+        # attached after the base mesh has been imported.
+        try:
+            static_mesh.import_mesh_lods = bool(import_lods)
+        except Exception:
+            pass
         static_mesh.combine_meshes = True
         static_mesh.generate_lightmap_u_vs = True
         

--- a/importer_config.json
+++ b/importer_config.json
@@ -5,5 +5,6 @@
     "auto_create_mi": true,
     "auto_assign_to_mesh": true,
     "replace_existing": false,
-    "organize_asset": true
+    "organize_asset": true,
+    "auto_import_lods": true
 }

--- a/tests/smoke_test_lod_unreal.py
+++ b/tests/smoke_test_lod_unreal.py
@@ -1,0 +1,32 @@
+"""Verify the embedded and separate-file Static Mesh LOD APIs in Unreal."""
+
+import sys
+from pathlib import Path
+
+import unreal
+
+
+repository_root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(repository_root))
+for module_name in tuple(sys.modules):
+    if module_name == "asset_port" or module_name.startswith("asset_port."):
+        del sys.modules[module_name]
+
+from asset_port.detector import AssetDetector  # noqa: E402
+from asset_port.presets import get_mesh_setting  # noqa: E402
+
+
+asset = AssetDetector().detect_file("SM_Test_LOD0.fbx")
+fbx = get_mesh_setting(asset)
+assert bool(fbx.static_mesh_import_data.import_mesh_lods) is True
+fbx_without_lods = get_mesh_setting(asset, import_lods=False)
+assert bool(fbx_without_lods.static_mesh_import_data.import_mesh_lods) is False
+
+subsystem_class = getattr(unreal, "StaticMeshEditorSubsystem", None)
+subsystem = unreal.get_editor_subsystem(subsystem_class) if subsystem_class else None
+legacy = getattr(unreal, "EditorStaticMeshLibrary", None)
+assert (subsystem and hasattr(subsystem, "import_lod")) or (
+    legacy and hasattr(legacy, "import_lod")
+)
+
+unreal.log("AssetPort Static Mesh LOD API smoke test passed.")

--- a/tests/test_lod_grouping.py
+++ b/tests/test_lod_grouping.py
@@ -1,0 +1,49 @@
+import unittest
+
+from asset_port.detector import AssetDetector
+
+
+class LodGroupingTests(unittest.TestCase):
+    def setUp(self):
+        self.detector = AssetDetector()
+
+    def test_separate_lod_files_share_one_asset_group(self):
+        base = self.detector.detect_file("SM_env_Rock_LOD0.fbx")
+        lod1 = self.detector.detect_file("SM_Rock_LOD1.fbx")
+        lod2 = self.detector.detect_file("SM_Rock_LOD2.fbx")
+
+        groups = self.detector.group_assets([base, lod2, lod1])
+
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0].mesh.lod_index, 0)
+        self.assertEqual([item.lod_index for item in groups[0].lod_meshes], [2, 1])
+        self.assertTrue(all(item.category == "Environment" for item in groups[0].lod_meshes))
+
+    def test_unsuffixed_mesh_is_preferred_over_lod_zero(self):
+        lod0 = self.detector.detect_file("SM_Rock_LOD0.fbx")
+        base = self.detector.detect_file("SM_Rock.fbx")
+
+        group = self.detector.group_assets([lod0, base])[0]
+
+        self.assertIsNone(group.mesh.lod_index)
+
+    def test_atlas_lods_are_keyed_by_clean_mesh_name(self):
+        base = self.detector.detect_file("SM_env_Rock01-RockKit.fbx")
+        lod1 = self.detector.detect_file("SM_Rock01-RockKit_LOD1.fbx")
+        texture = self.detector.detect_file("T_RockKit_D.png")
+
+        groups, remaining = self.detector.group_atlas_assets([base, lod1, texture])
+
+        self.assertEqual(remaining, [])
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0].lod_meshes["SM_Rock01"][0].lod_index, 1)
+        self.assertEqual(groups[0].lod_meshes["SM_Rock01"][0].category, "Environment")
+
+    def test_lod_marker_is_only_removed_from_fbx_files(self):
+        texture = self.detector.detect_file("T_Rock_LOD1.png")
+
+        self.assertIsNone(texture.lod_index)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- enable LOD groups embedded in a Static Mesh FBX
- detect and attach separately exported `_LOD0`, `_LOD1`, ... FBX files
- support both regular asset groups and Atlas/modular kits
- add `auto_import_lods` configuration, progress/report counts, naming documentation, and tests

## Scope

This PR contains only the generally useful Static Mesh LOD workflow. It does not include AssetPort-CN localization, Decal materials, CN assets, or CN release metadata. Separate-file Skeletal Mesh LODs are intentionally left on the existing import path and are not merged into Static Mesh handling.

## Testing

- `python -m unittest discover -s tests -p 'test_*.py'` — 11 tests passed
- AST parsed all 15 Python source/test files
- UE 5.7 Python commandlet smoke test — success, 0 errors and 0 warnings
  - verified embedded `import_mesh_lods` on/off behavior
  - verified `StaticMeshEditorSubsystem.import_lod` or legacy fallback availability

A production FBX fixture is not included in the repository, so the automated UE smoke test validates settings and API availability; the grouping behavior is covered by deterministic unit tests.