### PR TITLE
feat: add smart nanite auto-enable

### DIFF
--- a/asset_port/config.py
+++ b/asset_port/config.py
@@ -12,6 +12,8 @@ class ImporterSettings():
     replace_existing : bool = False
     organize_asset : bool = True
     auto_import_lods : bool = True
+    smart_nanite: bool = True
+    nanite_min_triangles: int = 2500
 
 def config_loader():
     

--- a/asset_port/importer.py
+++ b/asset_port/importer.py
@@ -2,7 +2,7 @@ import unreal
 from pathlib import Path
 from asset_port.detector import AssetDetector
 from asset_port.router import AssetRouter
-from asset_port.presets import get_mesh_setting, texture_settings
+from asset_port.presets import get_mesh_setting, texture_settings, evaluate_smart_nanite, apply_nanite_settings
 from asset_port.models import AssetType, PipelineReport, TextureSlot, AtlasGroup
 from asset_port.Validator import asset_validator, group_validator, atlas_group_validator
 from asset_port.config import config_loader
@@ -72,8 +72,29 @@ class AssetImporter():
         for group in group_asset:
             if isinstance(group, AtlasGroup):
                 mi_report = create_atlas_material_instance(group, self.config, decisions)
+                blend_mode = decisions.get(f"MI_{group.kit_name}", "Opaque") if decisions else "Opaque"
+                for mesh in group.mesh_list:
+                    if mesh.ue_path:
+                        mesh_obj = unreal.EditorAssetLibrary.load_asset(mesh.ue_path)
+                        if mesh_obj and evaluate_smart_nanite(mesh_obj, group, self.config, blend_mode):
+                            apply_nanite_settings(mesh_obj, True)
+                            unreal.EditorAssetLibrary.save_loaded_asset(mesh_obj)
+                            
             else:
                 mi_report = create_material_instance(group, self.config, decisions)
+                
+                if group.mesh and group.mesh.ue_path:
+                    mesh_obj = unreal.EditorAssetLibrary.load_asset(group.mesh.ue_path)
+                    if group.is_multi_material:
+                        is_transparent = any(decisions.get(f"MI_{group.base_name}_{slot}", "Opaque") in ("Masked", "Translucent")
+                        for slot in group.material_slots) if decisions else False
+                        blend_mode = "Masked" if is_transparent else "Opaque"
+                    else:
+                        blend_mode = decisions.get(f"MI_{group.base_name}", "Opaque") if decisions else "Opaque"
+                    if mesh_obj and evaluate_smart_nanite(mesh_obj,group,self.config, blend_mode):
+                        apply_nanite_settings(mesh_obj,True)
+                        unreal.EditorAssetLibrary.save_loaded_asset(mesh_obj)
+                        
             if report and mi_report.success:
                 report.mis_created += 1
                 if mi_report.mesh_linked:

--- a/asset_port/presets.py
+++ b/asset_port/presets.py
@@ -67,3 +67,27 @@ def texture_settings(texture_asset, slot: TextureSlot):
     if slot == TextureSlot.TRANSLUCENCY:
         texture_asset.srgb = True
         texture_asset.compression_settings =unreal.TextureCompressionSettings.TC_DEFAULT
+
+def evaluate_smart_nanite(mesh_obj, group, config, blend_mode = "Opaque") -> bool:
+    
+    if not getattr(config, "smart_nanite", True):
+        return False
+    if not isinstance(mesh_obj, unreal.StaticMesh):
+        return False
+    if group.lod_meshes:
+        return False
+    if blend_mode in ("Masked", "Translucent"):
+        return False
+    min_tris = getattr(config, "nanite_min_triangles", 2500)
+    if mesh_obj.get_num_triangles(0) <= min_tris:
+        return False
+    
+    return True
+
+
+def apply_nanite_settings(mesh_obj, enabled: bool):
+    
+    nanite = mesh_obj.get_editor_property("nanite_settings")
+    nanite.b_enabled = enabled
+    mesh_obj.set_editor_property("nanite_settings", nanite)
+    

--- a/asset_port/presets.py
+++ b/asset_port/presets.py
@@ -74,7 +74,7 @@ def evaluate_smart_nanite(mesh_obj, group, config, blend_mode = "Opaque") -> boo
         return False
     if not isinstance(mesh_obj, unreal.StaticMesh):
         return False
-    if group.lod_meshes:
+    if group.lod_meshes or mesh_obj.get_num_lods() > 1:
         return False
     if blend_mode in ("Masked", "Translucent"):
         return False
@@ -86,8 +86,15 @@ def evaluate_smart_nanite(mesh_obj, group, config, blend_mode = "Opaque") -> boo
 
 
 def apply_nanite_settings(mesh_obj, enabled: bool):
-    
     nanite = mesh_obj.get_editor_property("nanite_settings")
-    nanite.b_enabled = enabled
+    nanite.enabled = enabled
+
+    subsystem = unreal.get_editor_subsystem(unreal.StaticMeshEditorSubsystem)
+    if subsystem and hasattr(subsystem, "set_nanite_settings"):
+        subsystem.set_nanite_settings(mesh_obj, nanite, apply_changes=True)
+        return
+
+    # fallback
     mesh_obj.set_editor_property("nanite_settings", nanite)
+    unreal.log_warning(f"Nanite subsystem unavailable — settings applied to {mesh_obj.get_name()} but build not triggered")
     

--- a/importer_config.json
+++ b/importer_config.json
@@ -6,5 +6,7 @@
     "auto_assign_to_mesh": true,
     "replace_existing": false,
     "organize_asset": true,
-    "auto_import_lods": true
+    "auto_import_lods": true,
+    "smart_nanite":true,
+    "nanite_min_triangles": 2500   
 }

--- a/tests/test_smart_nanite.py
+++ b/tests/test_smart_nanite.py
@@ -1,0 +1,45 @@
+import sys
+import unittest
+from unittest.mock import MagicMock
+# Allow running tests headlessly outside of Unreal Engine:
+if "unreal" not in sys.modules:
+    mock_unreal = MagicMock()
+    class MockStaticMesh:
+        def __init__(self, triangles=3000, num_lods=1):
+            self._triangles = triangles
+            self._num_lods = num_lods
+            
+        def get_num_triangles(self, lod_index=0):
+            return self._triangles
+            
+        def get_num_lods(self):
+            return self._num_lods
+    mock_unreal.StaticMesh = MockStaticMesh
+    sys.modules["unreal"] = mock_unreal
+import unreal
+from asset_port.presets import evaluate_smart_nanite
+from asset_port.models import AssetGroup, DetectedAsset, AssetType
+from asset_port.config import ImporterSettings
+
+class SmartNaniteTests(unittest.TestCase):
+    def setUp(self):
+        self.config = ImporterSettings(smart_nanite=True, nanite_min_triangles=2500)
+    def test_dense_opaque_mesh_enables_nanite(self):
+        mesh = unreal.StaticMesh(triangles=3000)
+        group = AssetGroup(base_name="SM_Rock")
+        self.assertTrue(evaluate_smart_nanite(mesh, group, self.config, "Opaque"))
+    def test_low_poly_mesh_disables_nanite(self):
+        mesh = unreal.StaticMesh(triangles=500)
+        group = AssetGroup(base_name="SM_Box")
+        self.assertFalse(evaluate_smart_nanite(mesh, group, self.config, "Opaque"))
+    def test_embedded_fbx_lods_disables_nanite(self):
+        mesh = unreal.StaticMesh(triangles=5000, num_lods=4)
+        group = AssetGroup(base_name="SM_Tree")
+        self.assertFalse(evaluate_smart_nanite(mesh, group, self.config, "Opaque"))
+    def test_transparent_or_masked_disables_nanite(self):
+        mesh = unreal.StaticMesh(triangles=5000)
+        group = AssetGroup(base_name="SM_Glass")
+        self.assertFalse(evaluate_smart_nanite(mesh, group, self.config, "Masked"))
+        self.assertFalse(evaluate_smart_nanite(mesh, group, self.config, "Translucent"))
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary
Automatically enables Nanite on imported static meshes if they don't have LODs, aren't masked/translucent, and have more than 2,500 triangles.

### Changes
- Added `smart_nanite` and `nanite_min_triangles` to config.
- Checks triangle count, separate `_LOD1` files, and embedded FBX LODs before enabling Nanite.
- Safe for multi-material meshes (disables Nanite if any slot is masked/translucent) and Atlas kits.
- Uses `StaticMeshEditorSubsystem` to compile Nanite mesh clusters properly.
- Added unit tests in `tests/test_smart_nanite.py` (all passing).